### PR TITLE
Implement GlobalMemory skeleton

### DIFF
--- a/py_virtual_gpu/global_memory.py
+++ b/py_virtual_gpu/global_memory.py
@@ -1,9 +1,105 @@
-"""Placeholder for the GlobalMemory class implementation."""
+"""Global memory simulation using ``multiprocessing.Array``.
+
+This module defines :class:`GlobalMemory`, a simple manager for a chunk of
+bytes that is shared among processes. It is deliberately minimal and will
+be expanded in later issues.
+"""
+
+from __future__ import annotations
+
+from multiprocessing import Array, Lock
+from ctypes import c_byte
+from typing import Dict, List, Tuple
 
 
 class GlobalMemory:
     """Simulated global memory accessible to all thread blocks."""
 
     def __init__(self, size: int) -> None:
-        self.size = size
-        raise NotImplementedError
+        """Create a block of ``size`` bytes backed by shared memory."""
+        self.size: int = size
+        self.buffer = Array(c_byte, size, lock=False)
+        self.lock = Lock()
+        self.allocations: Dict[int, int] = {}
+        self._free_list: List[Tuple[int, int]] = [(0, size)]
+
+    # ------------------------------------------------------------------
+    # Allocation helpers
+    # ------------------------------------------------------------------
+    def malloc(self, size: int) -> int:
+        """Allocate ``size`` bytes and return the starting offset."""
+        for idx, (offset, block_size) in enumerate(self._free_list):
+            if block_size >= size:
+                self.allocations[offset] = size
+                if block_size == size:
+                    del self._free_list[idx]
+                else:
+                    self._free_list[idx] = (offset + size, block_size - size)
+                return offset
+        raise MemoryError("Out of global memory")
+
+    def free(self, ptr: int) -> None:
+        """Free a previously allocated block at ``ptr``."""
+        size = self.allocations.pop(ptr, None)
+        if size is None:
+            return
+        self._free_list.append((ptr, size))
+        self._free_list.sort()
+        merged: List[Tuple[int, int]] = []
+        for off, sz in self._free_list:
+            if not merged:
+                merged.append((off, sz))
+                continue
+            last_off, last_sz = merged[-1]
+            if last_off + last_sz == off:
+                merged[-1] = (last_off, last_sz + sz)
+            else:
+                merged.append((off, sz))
+        self._free_list = merged
+
+    # ------------------------------------------------------------------
+    # Raw memory access
+    # ------------------------------------------------------------------
+    def read(self, ptr: int, size: int) -> bytes:
+        """Return ``size`` bytes from ``ptr``."""
+        with self.lock:
+            return bytes(self.buffer[ptr : ptr + size])
+
+    def write(self, ptr: int, data: bytes) -> None:
+        """Write ``data`` starting at ``ptr``."""
+        with self.lock:
+            self.buffer[ptr : ptr + len(data)] = data
+
+    def memcpy(self, dest_ptr: int, src: int | bytes, size: int, direction: str) -> bytes | None:
+        """Copy memory between host and device.
+
+        Parameters
+        ----------
+        dest_ptr:
+            Destination offset inside the device memory when copying
+            Host->Device or Device->Device.
+        src:
+            Source bytes when copying Host->Device, or source offset when
+            Device->Device. Ignored for Device->Host.
+        size:
+            Number of bytes to transfer.
+        direction:
+            One of ``'HostToDevice'``, ``'DeviceToHost'`` or ``'DeviceToDevice'``.
+        """
+        if direction == "HostToDevice":
+            if not isinstance(src, (bytes, bytearray)):
+                raise TypeError("src must be bytes for HostToDevice copies")
+            self.write(dest_ptr, bytes(src[:size]))
+            return None
+        if direction == "DeviceToHost":
+            return self.read(dest_ptr, size)
+        if direction == "DeviceToDevice":
+            if not isinstance(src, int):
+                raise TypeError("src must be an int offset for DeviceToDevice")
+            temp = self.read(src, size)
+            self.write(dest_ptr, temp)
+            return None
+        raise ValueError(f"Unknown direction: {direction}")
+
+__all__ = ["GlobalMemory"]
+

--- a/tests/test_global_memory.py
+++ b/tests/test_global_memory.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import GlobalMemory
+
+
+def test_malloc_write_read():
+    gm = GlobalMemory(32)
+    ptr = gm.malloc(8)
+    gm.write(ptr, b"abcdefgh")
+    assert gm.read(ptr, 8) == b"abcdefgh"
+
+
+def test_malloc_free_reuse():
+    gm = GlobalMemory(16)
+    p1 = gm.malloc(4)
+    p2 = gm.malloc(4)
+    gm.free(p1)
+    p3 = gm.malloc(4)
+    assert p3 == p1  # first-fit reuse
+    assert p2 != p1
+
+
+def test_memcpy_host_device_and_back():
+    gm = GlobalMemory(16)
+    ptr = gm.malloc(6)
+    gm.memcpy(ptr, b"abcdef", 6, "HostToDevice")
+    out = gm.memcpy(ptr, None, 6, "DeviceToHost")
+    assert out == b"abcdef"
+
+
+def test_memcpy_device_to_device():
+    gm = GlobalMemory(16)
+    src = gm.malloc(4)
+    dest = gm.malloc(4)
+    gm.write(src, b"1234")
+    gm.memcpy(dest, src, 4, "DeviceToDevice")
+    assert gm.read(dest, 4) == b"1234"
+


### PR DESCRIPTION
## Summary
- implement the `GlobalMemory` class backed by `multiprocessing.Array`
- provide allocation/free and memcpy helpers
- add unit tests for the new class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d3cb23708331acf026366865245a