### PR TITLE
Implement Thread and RegisterMemory classes

### DIFF
--- a/py_virtual_gpu/thread.py
+++ b/py_virtual_gpu/thread.py
@@ -1,9 +1,85 @@
-"""Minimal ``Thread`` placeholder for type hints."""
+"""Thread execution unit and register memory abstractions."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Tuple
+
+from .shared_memory import SharedMemory
+from .global_memory import GlobalMemory
+
+
+class RegisterMemory:
+    """Simple key-value store representing registers of a thread."""
+
+    def __init__(self, size_bytes: int) -> None:
+        self.size: int = size_bytes
+        self._storage: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Basic register operations
+    # ------------------------------------------------------------------
+    def read(self, name: str) -> Any:
+        """Return the value stored in register ``name`` or ``None``."""
+
+        return self._storage.get(name)
+
+    def write(self, name: str, value: Any) -> None:
+        """Write ``value`` into register ``name``."""
+
+        self._storage[name] = value
+
+    def clear(self) -> None:
+        """Clear all registers."""
+
+        self._storage.clear()
+
 
 class Thread:
-    """Represents a single kernel thread (placeholder)."""
+    """Represent a single kernel thread with its own register set."""
 
-    def __init__(self) -> None:
-        pass
+    def __init__(
+        self,
+        thread_idx: Tuple[int, int, int] | None = None,
+        block_idx: Tuple[int, int, int] | None = None,
+        block_dim: Tuple[int, int, int] | None = None,
+        grid_dim: Tuple[int, int, int] | None = None,
+        register_mem_size: int = 0,
+        shared_mem: SharedMemory | None = None,
+        global_mem: GlobalMemory | None = None,
+    ) -> None:
+        # Indices and dimensions
+        self.thread_idx: Tuple[int, int, int] = thread_idx or (0, 0, 0)
+        self.block_idx: Tuple[int, int, int] = block_idx or (0, 0, 0)
+        self.block_dim: Tuple[int, int, int] = block_dim or (1, 1, 1)
+        self.grid_dim: Tuple[int, int, int] = grid_dim or (1, 1, 1)
 
-__all__ = ["Thread"]
+        # Private register memory
+        self.registers = RegisterMemory(register_mem_size)
+
+        # Memory references
+        self.shared_mem = shared_mem
+        self.global_mem = global_mem
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+    def run(self, kernel_func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+        """Execute ``kernel_func`` for this thread (stub)."""
+
+        raise NotImplementedError(
+            "Stub de execução de thread – implementar logicamente na issue 3.x"
+        )
+
+    # ------------------------------------------------------------------
+    # Representation helpers
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        tx, ty, tz = self.thread_idx
+        bx, by, bz = self.block_idx
+        return (
+            f"<Thread idx=({tx},{ty},{tz}) blk=({bx},{by},{bz}) "
+            f"regs={len(self.registers._storage)}>"
+        )
+
+
+__all__ = ["RegisterMemory", "Thread"]

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.thread import Thread, RegisterMemory
+from py_virtual_gpu.shared_memory import SharedMemory
+from py_virtual_gpu.global_memory import GlobalMemory
+
+
+def test_register_memory_read_write_clear():
+    rm = RegisterMemory(1024)
+    rm.write("a", 123)
+    assert rm.read("a") == 123
+    rm.clear()
+    assert rm.read("a") is None
+
+
+def test_thread_attributes():
+    sm = SharedMemory(16)
+    gm = GlobalMemory(32)
+    t = Thread((0, 0, 0), (1, 2, 3), (4, 4, 1), (8, 8, 1), 256, sm, gm)
+    assert t.thread_idx == (0, 0, 0)
+    assert t.block_idx == (1, 2, 3)
+    assert t.block_dim == (4, 4, 1)
+    assert t.grid_dim == (8, 8, 1)
+    assert isinstance(t.registers, RegisterMemory)
+    assert t.registers.size == 256
+
+
+def test_run_stub_raises():
+    sm = SharedMemory(1)
+    gm = GlobalMemory(1)
+    t = Thread(register_mem_size=4, shared_mem=sm, global_mem=gm)
+    with pytest.raises(NotImplementedError) as exc:
+        t.run(lambda: None)
+    assert "Stub de execução de thread" in str(exc.value)
+
+
+def test_repr_contains_indices_and_register_count():
+    sm = SharedMemory(1)
+    gm = GlobalMemory(1)
+    t = Thread((0, 0, 0), (0, 0, 0), (1, 1, 1), (1, 1, 1), 0, sm, gm)
+    text = repr(t)
+    assert "idx=(0,0,0)" in text
+    assert "blk=(0,0,0)" in text
+    assert "regs=0" in text
+

--- a/tests/test_thread_block.py
+++ b/tests/test_thread_block.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -23,7 +24,8 @@ def test_initialize_threads_creates_all():
 
 def test_execute_runs_without_error():
     tb = ThreadBlock((0, 0, 0), (1, 1, 1), (1, 1, 1), shared_mem_size=1)
-    tb.execute(lambda *a: None)
+    with pytest.raises(NotImplementedError):
+        tb.execute(lambda *a: None)
     assert len(tb.threads) == 1
 
 


### PR DESCRIPTION
## Summary
- add RegisterMemory and Thread classes with stubbed execution
- update thread block test to expect NotImplementedError
- add tests for register and thread behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d95a0e208331a80046b35628e9c3