### PR TITLE
Implement SharedMemory with atomic operations

### DIFF
--- a/py_virtual_gpu/shared_memory.py
+++ b/py_virtual_gpu/shared_memory.py
@@ -1,17 +1,56 @@
-"""Minimal shared memory placeholder used by ``StreamingMultiprocessor``."""
+"""Shared memory simulation used by :class:`ThreadBlock`."""
+
+from __future__ import annotations
+
+from multiprocessing import Array, Lock
+from ctypes import c_byte
+
 
 class SharedMemory:
     """Simple byte-addressable shared memory buffer."""
 
     def __init__(self, size: int) -> None:
-        self.size = size
-        self.buffer = bytearray(size)
+        """Create a shared buffer of ``size`` bytes."""
 
+        self.size: int = size
+        self.buffer = Array(c_byte, size, lock=False)
+        self.lock = Lock()
+
+    # ------------------------------------------------------------------
+    # Basic accessors
+    # ------------------------------------------------------------------
     def read(self, offset: int, size: int) -> bytes:
-        return bytes(self.buffer[offset : offset + size])
+        """Return ``size`` bytes starting from ``offset``."""
+
+        if offset < 0 or offset + size > self.size:
+            raise IndexError("SharedMemory read out of bounds")
+        view = memoryview(self.buffer)
+        return view[offset : offset + size].tobytes()
 
     def write(self, offset: int, data: bytes) -> None:
-        self.buffer[offset : offset + len(data)] = data
+        """Write ``data`` starting at ``offset``."""
+
+        end = offset + len(data)
+        if offset < 0 or end > self.size:
+            raise IndexError("SharedMemory write out of bounds")
+        self.buffer[offset:end] = data
+
+    # ------------------------------------------------------------------
+    # Atomic operations
+    # ------------------------------------------------------------------
+    def atomic_add(self, offset: int, value: int, num_bytes: int = 4) -> int:
+        """Atomically add ``value`` to an integer stored at ``offset``."""
+
+        if offset < 0 or offset + num_bytes > self.size:
+            raise IndexError("SharedMemory atomic out of bounds")
+        with self.lock:
+            raw = memoryview(self.buffer)[offset : offset + num_bytes].tobytes()
+            old = int.from_bytes(raw, byteorder="little", signed=True)
+            new = old + value
+            self.buffer[offset : offset + num_bytes] = new.to_bytes(
+                num_bytes, byteorder="little", signed=True
+            )
+            return old
 
 
 __all__ = ["SharedMemory"]

--- a/tests/test_shared_memory.py
+++ b/tests/test_shared_memory.py
@@ -1,0 +1,44 @@
+import os, sys, multiprocessing as mp, pytest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.shared_memory import SharedMemory
+
+
+def test_read_write_basic():
+    sm = SharedMemory(16)
+    sm.write(4, b"abc")
+    assert sm.read(4, 3) == b"abc"
+
+
+def test_bounds_check():
+    sm = SharedMemory(8)
+    with pytest.raises(IndexError):
+        sm.read(7, 2)
+    with pytest.raises(IndexError):
+        sm.write(7, b"\x00\x01")
+
+
+def test_atomic_add():
+    sm = SharedMemory(4)
+    sm.write(0, (5).to_bytes(4, "little", signed=True))
+    old = sm.atomic_add(0, 7)
+    assert old == 5
+    val = int.from_bytes(sm.read(0, 4), "little", signed=True)
+    assert val == 12
+
+
+def _worker_add(shared, loops):
+    for _ in range(loops):
+        shared.atomic_add(0, 1)
+
+
+def test_atomic_add_concurrent():
+    sm = SharedMemory(4)
+    sm.write(0, (0).to_bytes(4, "little", signed=True))
+    processes = [mp.Process(target=_worker_add, args=(sm, 1000)) for _ in range(4)]
+    for p in processes:
+        p.start()
+    for p in processes:
+        p.join()
+    result = int.from_bytes(sm.read(0, 4), "little", signed=True)
+    assert result == 4000


### PR DESCRIPTION
## Summary
- enhance `SharedMemory` to use shared `multiprocessing.Array`
- add bounds checks and atomic add support
- create tests covering read/write, bounds errors and atomic ops including concurrent scenario

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e241e53883319c3e305467e36417