### PR TITLE
Implement warp groups and scheduling

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -4,11 +4,13 @@ from .virtualgpu import VirtualGPU
 from .global_memory import GlobalMemory
 from .streaming_multiprocessor import StreamingMultiprocessor
 from .thread_block import ThreadBlock
+from .warp import Warp
 
 __all__ = [
     "VirtualGPU",
     "GlobalMemory",
     "StreamingMultiprocessor",
     "ThreadBlock",
+    "Warp",
 ]
 

--- a/py_virtual_gpu/warp.py
+++ b/py_virtual_gpu/warp.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import List
+
+from .thread import Thread
+
+
+class Warp:
+    """Represent a group of threads executing in lock-step."""
+
+    def __init__(self, id: int, threads: List[Thread]):
+        self.id: int = id
+        self.threads: List[Thread] = threads
+        self.active_mask: List[bool] = [True] * len(threads)
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+    def execute(self) -> None:
+        """Execute one instruction for all active threads (stub)."""
+
+        raise NotImplementedError(
+            "Execu\u00e7\u00e3o de warp stub – implementar em 3.x"
+        )
+
+    # ------------------------------------------------------------------
+    # Representation helpers
+    # ------------------------------------------------------------------
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        active = sum(self.active_mask)
+        return f"<Warp id={self.id} size={len(self.threads)} active={active}>"
+
+
+__all__ = ["Warp"]

--- a/tests/test_streaming_multiprocessor.py
+++ b/tests/test_streaming_multiprocessor.py
@@ -5,6 +5,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from py_virtual_gpu.streaming_multiprocessor import StreamingMultiprocessor
+from py_virtual_gpu.warp import Warp
 
 
 class DummyThread:
@@ -19,6 +20,8 @@ class DummyBlock:
 def test_sm_instantiation_and_queue():
     sm = StreamingMultiprocessor(id=0, shared_mem_size=256, max_registers_per_thread=16)
     assert sm.block_queue.empty()
+    assert sm.warp_queue.empty()
+    assert sm.schedule_policy == "round_robin"
     sm.block_queue.put(DummyBlock(1))
     assert sm.block_queue.qsize() == 1
 
@@ -26,17 +29,72 @@ def test_sm_instantiation_and_queue():
 def test_execute_block_warp_count():
     sm = StreamingMultiprocessor(id=0, shared_mem_size=128, max_registers_per_thread=16, warp_size=32)
     block = DummyBlock(65)
+    # Prevent NotImplementedError from Warp.execute
+    def _nop(self):
+        self.active_mask = [False] * len(self.active_mask)
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(Warp, "execute", _nop)
     sm.execute_block(block)
+    monkeypatch.undo()
+    assert sm.warp_queue.empty()
     assert sm.counters["warps_executed"] == 3
+
+
+def test_sequential_policy_executes_each_warp_once():
+    sm = StreamingMultiprocessor(id=1, shared_mem_size=128, max_registers_per_thread=16, warp_size=2)
+    sm.schedule_policy = "sequential"
+    block = DummyBlock(4)
+
+    order = []
+
+    def _record(self):
+        order.append(self.id)
+        self.active_mask = [False] * len(self.active_mask)
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(Warp, "execute", _record)
+    sm.execute_block(block)
+    mp.undo()
+
+    assert order == [0, 1]
+    assert sm.warp_queue.empty()
+
+
+def test_round_robin_reenqueues_active_warps():
+    sm = StreamingMultiprocessor(id=2, shared_mem_size=128, max_registers_per_thread=16, warp_size=2)
+    sm.schedule_policy = "round_robin"
+    block = DummyBlock(4)
+
+    call_count = {0: 0, 1: 0}
+
+    def _toggle(self):
+        call_count[self.id] += 1
+        if self.id == 0 and call_count[self.id] == 1:
+            # remain active so it will be re-enqueued
+            self.active_mask[0] = False
+            self.active_mask[1] = True
+        else:
+            self.active_mask = [False] * len(self.active_mask)
+
+    mp = pytest.MonkeyPatch()
+    mp.setattr(Warp, "execute", _toggle)
+    sm.execute_block(block)
+    mp.undo()
+
+    assert call_count[0] == 2
+    assert call_count[1] == 1
+    assert sm.warp_queue.empty()
 
 
 def test_reset_counters_and_queue():
     sm = StreamingMultiprocessor(id=0, shared_mem_size=128, max_registers_per_thread=16)
     sm.block_queue.put(DummyBlock(2))
+    sm.warp_queue.put(Warp(0, []))
     sm.counters["warps_executed"] = 5
     sm.counters["warp_divergences"] = 2
     sm.reset()
     assert sm.block_queue.empty()
+    assert sm.warp_queue.empty()
     assert sm.counters["warps_executed"] == 0
     assert sm.counters["warp_divergences"] == 0
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.warp import Warp
+from py_virtual_gpu.thread import Thread
+
+
+def test_warp_attributes_and_execute_stub():
+    threads = [Thread() for _ in range(3)]
+    w = Warp(id=0, threads=threads)
+    assert w.id == 0
+    assert len(w.threads) == 3
+    assert w.active_mask == [True, True, True]
+    with pytest.raises(NotImplementedError):
+        w.execute()


### PR DESCRIPTION
## Summary
- add new `Warp` class to represent groups of threads
- extend `StreamingMultiprocessor` with warp queue and scheduling policies
- implement sequential and round-robin warp execution
- expose `Warp` in package init
- test warp creation and new scheduling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e40ea0708331a276eaee4b88e8fe