### PR TITLE
Add SIMT dispatch skeleton

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -5,6 +5,7 @@ from .global_memory import GlobalMemory
 from .streaming_multiprocessor import StreamingMultiprocessor
 from .thread_block import ThreadBlock
 from .warp import Warp
+from .dispatch import Instruction, SIMTStack
 
 __all__ = [
     "VirtualGPU",
@@ -12,5 +13,7 @@ __all__ = [
     "StreamingMultiprocessor",
     "ThreadBlock",
     "Warp",
+    "Instruction",
+    "SIMTStack",
 ]
 

--- a/py_virtual_gpu/dispatch.py
+++ b/py_virtual_gpu/dispatch.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+
+class Instruction:
+    """Represent a simplified instruction with an opcode and operands."""
+
+    def __init__(self, opcode: str, operands: Tuple):
+        self.opcode = opcode
+        self.operands = operands
+
+
+class SIMTStack:
+    """Manage thread masks and reconvergence PCs for divergence handling."""
+
+    def __init__(self) -> None:
+        self.stack: List[Tuple[List[bool], int]] = []
+
+    def push(self, mask: List[bool], reconv_pc: int) -> None:
+        self.stack.append((mask.copy(), reconv_pc))
+
+    def pop(self) -> Tuple[List[bool], int]:
+        return self.stack.pop() if self.stack else ([], -1)
+
+    def top(self) -> Tuple[List[bool], int]:
+        return self.stack[-1] if self.stack else ([], -1)
+
+
+__all__ = ["Instruction", "SIMTStack"]

--- a/py_virtual_gpu/warp.py
+++ b/py_virtual_gpu/warp.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import List
 
+from .dispatch import Instruction, SIMTStack
 from .thread import Thread
+
 
 
 class Warp:
@@ -12,6 +14,8 @@ class Warp:
         self.id: int = id
         self.threads: List[Thread] = threads
         self.active_mask: List[bool] = [True] * len(threads)
+        self.pc: int = 0
+        self.simt_stack = SIMTStack()
 
     # ------------------------------------------------------------------
     # Execution
@@ -22,6 +26,17 @@ class Warp:
         raise NotImplementedError(
             "Execu\u00e7\u00e3o de warp stub – implementar em 3.x"
         )
+    def issue_instruction(self, inst: Instruction) -> None:
+        """Issue ``inst`` to the active threads (conceptual stub)."""
+        self.pc += 1
+        raise NotImplementedError("Dispatch de instru\u00e7\u00e3o stub")
+
+    def handle_divergence(self, predicate: List[bool]) -> None:
+        """Handle control-flow divergence for this warp."""
+        reconv_pc = self.pc
+        self.simt_stack.push(self.active_mask, reconv_pc)
+        self.active_mask = predicate.copy()
+
 
     # ------------------------------------------------------------------
     # Representation helpers

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.dispatch import Instruction, SIMTStack
+from py_virtual_gpu.warp import Warp
+from py_virtual_gpu.thread import Thread
+from py_virtual_gpu.streaming_multiprocessor import StreamingMultiprocessor
+
+
+def test_instruction_and_simtstack_basic():
+    inst = Instruction("ADD", ("r1", "r2"))
+    assert inst.opcode == "ADD"
+    stack = SIMTStack()
+    stack.push([True, False], 5)
+    assert stack.top() == ([True, False], 5)
+    mask, pc = stack.pop()
+    assert (mask, pc) == ([True, False], 5)
+
+
+def test_warp_issue_instruction_stub():
+    w = Warp(0, [Thread(), Thread()])
+    inst = Instruction("NOP", tuple())
+    with pytest.raises(NotImplementedError):
+        w.issue_instruction(inst)
+
+
+def test_sm_dispatch_round_robin_stub():
+    sm = StreamingMultiprocessor(id=0, shared_mem_size=8, max_registers_per_thread=4, warp_size=2)
+    w1 = Warp(0, [Thread(), Thread()])
+    w2 = Warp(1, [Thread(), Thread()])
+    sm.warp_queue.put(w1)
+    sm.warp_queue.put(w2)
+    with pytest.raises(NotImplementedError):
+        sm.dispatch()
+
+
+def test_sm_record_divergence_counter():
+    sm = StreamingMultiprocessor(id=1, shared_mem_size=8, max_registers_per_thread=4)
+    assert sm.counters["warp_divergences"] == 0
+    sm.record_divergence([])
+    assert sm.counters["warp_divergences"] == 1
+

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -16,3 +16,7 @@ def test_warp_attributes_and_execute_stub():
     assert w.active_mask == [True, True, True]
     with pytest.raises(NotImplementedError):
         w.execute()
+    from py_virtual_gpu.dispatch import Instruction
+    inst = Instruction("NOP", tuple())
+    with pytest.raises(NotImplementedError):
+        w.issue_instruction(inst)


### PR DESCRIPTION
## Summary
- add `Instruction` and `SIMTStack` abstractions for warp dispatch
- extend `Warp` with PC tracking and divergence helpers
- add dispatch loop stub to `StreamingMultiprocessor`
- export new classes in package init
- test the new skeleton behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e67acbe08331a89c71cd1ddb0d27