### PR TITLE
Implement kernel decorator and GPU context helpers

### DIFF
--- a/py_virtual_gpu/kernel.py
+++ b/py_virtual_gpu/kernel.py
@@ -1,0 +1,56 @@
+"""Kernel function decorator and wrapper."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Callable, Optional, Tuple
+
+from .virtualgpu import VirtualGPU
+
+GridDim = Tuple[int, int, int]
+BlockDim = Tuple[int, int, int]
+
+
+class KernelFunction:
+    """Callable wrapper that dispatches execution to :class:`VirtualGPU`."""
+
+    def __init__(
+        self,
+        func: Callable[..., object],
+        grid_dim: Optional[GridDim],
+        block_dim: Optional[BlockDim],
+    ) -> None:
+        wraps(func)(self)
+        self._func = func
+        self.grid_dim = grid_dim
+        self.block_dim = block_dim
+
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        gd = self.grid_dim or kwargs.pop("grid_dim", None)
+        bd = self.block_dim or kwargs.pop("block_dim", None)
+        if gd is None or bd is None:
+            raise TypeError(
+                f"Kernel '{self.__name__}' requires grid_dim and block_dim"
+            )
+        gpu = VirtualGPU.get_current()
+        return gpu.launch_kernel(self._func, gd, bd, *args, **kwargs)
+
+
+def kernel(
+    func: Optional[Callable[..., object]] = None,
+    *,
+    grid_dim: Optional[GridDim] = None,
+    block_dim: Optional[BlockDim] = None,
+) -> Callable[[Callable[..., object]], KernelFunction] | KernelFunction:
+    """Decorate ``func`` turning it into a :class:`KernelFunction`."""
+
+    if func is None:
+        def wrapper(f: Callable[..., object]) -> KernelFunction:
+            return KernelFunction(f, grid_dim, block_dim)
+
+        return wrapper
+    return KernelFunction(func, grid_dim, block_dim)
+
+
+__all__ = ["kernel", "KernelFunction"]
+

--- a/py_virtual_gpu/virtualgpu.py
+++ b/py_virtual_gpu/virtualgpu.py
@@ -19,6 +19,22 @@ class VirtualGPU:
     the architectural overview in ``RESEARCH.md`` for the design rationale.
     """
 
+    _current: "VirtualGPU" | None = None
+
+    @classmethod
+    def set_current(cls, gpu: "VirtualGPU") -> None:
+        """Set ``gpu`` as the active device for kernel launches."""
+
+        cls._current = gpu
+
+    @classmethod
+    def get_current(cls) -> "VirtualGPU":
+        """Return the active device or raise ``RuntimeError`` if unset."""
+
+        if cls._current is None:
+            raise RuntimeError("No current VirtualGPU set")
+        return cls._current
+
     def __init__(self, num_sms: int, global_mem_size: int) -> None:
         """Initialize the virtual device with ``num_sms`` SMs and global memory.
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -1,0 +1,59 @@
+import pytest
+
+from py_virtual_gpu.kernel import kernel, KernelFunction
+from py_virtual_gpu.virtualgpu import VirtualGPU
+
+
+class DummyGPU(VirtualGPU):
+    def __init__(self):
+        super().__init__(0, 0)
+        self.calls = []
+
+    def launch_kernel(self, func, grid_dim, block_dim, *args, **kwargs):
+        self.calls.append((func, grid_dim, block_dim, args, kwargs))
+        return "ok"
+
+
+def test_decorator_without_params_and_explicit_dims():
+    gpu = DummyGPU()
+    VirtualGPU.set_current(gpu)
+
+    @kernel
+    def add(a, b):
+        return a + b
+
+    result = add(1, 2, grid_dim=(1, 1, 1), block_dim=(2, 2, 1))
+    assert result == "ok"
+    assert isinstance(add, KernelFunction)
+    assert gpu.calls[0][0].__name__ == "add"
+    assert gpu.calls[0][1] == (1, 1, 1)
+    assert gpu.calls[0][2] == (2, 2, 1)
+    assert gpu.calls[0][3] == (1, 2)
+
+
+def test_decorator_with_params_uses_defaults():
+    gpu = DummyGPU()
+    VirtualGPU.set_current(gpu)
+
+    @kernel(grid_dim=(4, 4, 1), block_dim=(8, 1, 1))
+    def mul(a, b):
+        return a * b
+
+    result = mul(3, 4)
+    assert result == "ok"
+    assert gpu.calls[0][1] == (4, 4, 1)
+    assert gpu.calls[0][2] == (8, 1, 1)
+
+
+def test_missing_dimensions_raises_type_error():
+    gpu = DummyGPU()
+    VirtualGPU.set_current(gpu)
+
+    @kernel
+    def noop():
+        pass
+
+    with pytest.raises(TypeError):
+        noop()
+
+


### PR DESCRIPTION
## Summary
- add `kernel` decorator and `KernelFunction` wrapper
- allow managing a current `VirtualGPU` for launches
- test kernel decorator behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f2095888833183e77fbdfd3f0af5