### PR TITLE
Implement kernel thread index injection

### DIFF
--- a/py_virtual_gpu/kernel.py
+++ b/py_virtual_gpu/kernel.py
@@ -12,7 +12,11 @@ BlockDim = Tuple[int, int, int]
 
 
 class KernelFunction:
-    """Callable wrapper that dispatches execution to :class:`VirtualGPU`."""
+    """Callable wrapper that dispatches execution to :class:`VirtualGPU`.
+
+    When invoked, the wrapped function receives ``threadIdx``, ``blockIdx``,
+    ``blockDim`` and ``gridDim`` as the first four positional arguments.
+    """
 
     def __init__(
         self,

--- a/py_virtual_gpu/thread.py
+++ b/py_virtual_gpu/thread.py
@@ -63,12 +63,35 @@ class Thread:
     # ------------------------------------------------------------------
     # Execution
     # ------------------------------------------------------------------
-    def run(self, kernel_func: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
-        """Execute ``kernel_func`` for this thread (stub)."""
+    def run(self, kernel_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Execute ``kernel_func`` injecting thread indices and dimensions.
 
-        raise NotImplementedError(
-            "Stub de execução de thread – implementar logicamente na issue 3.x"
-        )
+        Parameters
+        ----------
+        kernel_func:
+            Function representing the kernel to be executed.
+        *args:
+            Expected as ``(threadIdx, blockIdx, blockDim, gridDim, *user_args)``.
+
+        Returns
+        -------
+        Any
+            Whatever ``kernel_func`` returns.
+        """
+
+        if len(args) < 4:
+            raise TypeError(
+                "run expects threadIdx, blockIdx, blockDim and gridDim as the first four arguments"
+            )
+
+        threadIdx, blockIdx, blockDim, gridDim, *user_args = args
+        # expose as attributes used by the kernel
+        self.threadIdx = threadIdx
+        self.blockIdx = blockIdx
+        self.blockDim = blockDim
+        self.gridDim = gridDim
+
+        return kernel_func(threadIdx, blockIdx, blockDim, gridDim, *user_args, **kwargs)
 
     # ------------------------------------------------------------------
     # Representation helpers

--- a/py_virtual_gpu/thread_block.py
+++ b/py_virtual_gpu/thread_block.py
@@ -49,12 +49,19 @@ class ThreadBlock:
         self._initialized = True
 
     def execute(self, kernel_func: Callable[..., Any], *args: Any) -> None:
-        """Run all threads in this block (stub)."""
+        """Run all threads in this block invoking their ``run`` method."""
         self.initialize_threads(kernel_func, *args)
         for t in self.threads:
             run = getattr(t, "run", None)
             if callable(run):
-                run(kernel_func, *args)
+                params = (
+                    t.thread_idx,
+                    t.block_idx,
+                    t.block_dim,
+                    t.grid_dim,
+                    *args,
+                )
+                run(kernel_func, *params)
 
     # ------------------------------------------------------------------
     # Synchronization

--- a/tests/test_kernel_indices.py
+++ b/tests/test_kernel_indices.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.kernel import kernel
+from py_virtual_gpu.virtualgpu import VirtualGPU
+
+
+def test_kernel_receives_thread_and_block_indices():
+    gpu = VirtualGPU(0, 32)
+    gpu.sms = []  # execute synchronously
+    VirtualGPU.set_current(gpu)
+
+    results = []
+
+    @kernel(grid_dim=(2, 1, 1), block_dim=(2, 1, 1))
+    def collect(threadIdx, blockIdx, blockDim, gridDim, val):
+        results.append((threadIdx, blockIdx, blockDim, gridDim, val))
+
+    collect(5)
+
+    assert len(results) == 4
+    combos = set((t, b) for t, b, _, _, _ in results)
+    assert combos == {
+        ((0, 0, 0), (0, 0, 0)),
+        ((1, 0, 0), (0, 0, 0)),
+        ((0, 0, 0), (1, 0, 0)),
+        ((1, 0, 0), (1, 0, 0)),
+    }
+    for _, _, bdim, gdim, v in results:
+        assert bdim == (2, 1, 1)
+        assert gdim == (2, 1, 1)
+        assert v == 5

--- a/tests/test_thread_block.py
+++ b/tests/test_thread_block.py
@@ -22,11 +22,19 @@ def test_initialize_threads_creates_all():
     assert len(tb.threads) == 4
 
 
-def test_execute_runs_without_error():
-    tb = ThreadBlock((0, 0, 0), (1, 1, 1), (1, 1, 1), shared_mem_size=1)
-    with pytest.raises(NotImplementedError):
-        tb.execute(lambda *a: None)
-    assert len(tb.threads) == 1
+def test_execute_invokes_kernel_for_each_thread():
+    tb = ThreadBlock((0, 0, 0), (2, 1, 1), (1, 1, 1), shared_mem_size=1)
+    called = []
+
+    def kernel(tidx, bidx, bdim, gdim, value):
+        called.append((tidx, bidx, value))
+
+    tb.execute(kernel, 42)
+
+    assert len(tb.threads) == 2
+    assert len(called) == 2
+    expected = [((0, 0, 0), (0, 0, 0), 42), ((1, 0, 0), (0, 0, 0), 42)]
+    assert called == expected
 
 
 def test_repr_contains_info():


### PR DESCRIPTION
## Summary
- implement `Thread.run` to inject thread and block indices before invoking a kernel
- pass indices from `ThreadBlock.execute`
- document injection in `KernelFunction`
- update tests for thread and thread block behaviour
- add integration test for thread index access in kernels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f5bedeec83318f63b2eb1766765d