### PR TITLE
Implement warp divergence monitoring

### DIFF
--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -43,3 +43,21 @@ Um `ThreadBlock` é um agrupamento de threads que partilham uma região de `Shar
 - A classe `SharedMemory` expõe operações atômicas (`atomic_add`, `atomic_sub`,
   `atomic_cas`, `atomic_max`, `atomic_min`, `atomic_exchange`) que permitem
   atualização segura de valores compartilhados entre threads.
+
+## Monitoramento de Divergência
+
+O ``StreamingMultiprocessor`` registra eventos de divergência de warp toda vez
+que a máscara de threads ativas muda devido a um branch. Esses eventos podem ser
+obtidos com ``get_divergence_log()`` para análise posterior. O exemplo abaixo
+ilustra como construir um gráfico simples do número acumulado de divergências em
+função do ``pc`` de cada evento:
+
+```python
+log = sm.get_divergence_log()
+pcs = [e.pc for e in log]
+divs = list(range(1, len(log) + 1))
+plt.plot(pcs, divs)
+plt.xlabel("PC")
+plt.ylabel("Divergências acumuladas")
+plt.show()
+```

--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -3,7 +3,7 @@
 from .virtualgpu import VirtualGPU
 from .global_memory import GlobalMemory
 from .memory import DevicePointer
-from .streaming_multiprocessor import StreamingMultiprocessor
+from .streaming_multiprocessor import StreamingMultiprocessor, DivergenceEvent
 from .thread_block import ThreadBlock
 from .warp import Warp
 from .dispatch import Instruction, SIMTStack
@@ -17,5 +17,6 @@ __all__ = [
     "Instruction",
     "SIMTStack",
     "DevicePointer",
+    "DivergenceEvent",
 ]
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -21,7 +21,8 @@ def test_instruction_and_simtstack_basic():
 
 
 def test_warp_issue_instruction_stub():
-    w = Warp(0, [Thread(), Thread()])
+    sm = StreamingMultiprocessor(id=0, shared_mem_size=0, max_registers_per_thread=0, warp_size=2)
+    w = Warp(0, [Thread(), Thread()], sm)
     inst = Instruction("NOP", tuple())
     with pytest.raises(NotImplementedError):
         w.issue_instruction(inst)
@@ -29,8 +30,8 @@ def test_warp_issue_instruction_stub():
 
 def test_sm_dispatch_round_robin_stub():
     sm = StreamingMultiprocessor(id=0, shared_mem_size=8, max_registers_per_thread=4, warp_size=2)
-    w1 = Warp(0, [Thread(), Thread()])
-    w2 = Warp(1, [Thread(), Thread()])
+    w1 = Warp(0, [Thread(), Thread()], sm)
+    w2 = Warp(1, [Thread(), Thread()], sm)
     sm.warp_queue.put(w1)
     sm.warp_queue.put(w2)
     with pytest.raises(NotImplementedError):
@@ -40,6 +41,6 @@ def test_sm_dispatch_round_robin_stub():
 def test_sm_record_divergence_counter():
     sm = StreamingMultiprocessor(id=1, shared_mem_size=8, max_registers_per_thread=4)
     assert sm.counters["warp_divergences"] == 0
-    sm.record_divergence([])
+    sm.record_divergence(Warp(0, [Thread(), Thread()], sm), 0, [True, True], [False, True])
     assert sm.counters["warp_divergences"] == 1
 

--- a/tests/test_divergence_monitoring.py
+++ b/tests/test_divergence_monitoring.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.streaming_multiprocessor import StreamingMultiprocessor
+from py_virtual_gpu.warp import Warp
+from py_virtual_gpu.thread import Thread
+from py_virtual_gpu.dispatch import Instruction
+
+
+def test_divergence_events_and_log(monkeypatch):
+    sm = StreamingMultiprocessor(id=0, shared_mem_size=0, max_registers_per_thread=0, warp_size=2)
+    w = Warp(0, [Thread(), Thread()], sm)
+
+    monkeypatch.setattr(Warp, "fetch_next_instruction", lambda self: Instruction("BR", tuple()))
+    masks = [[True, False], [True, True]]
+    monkeypatch.setattr(Warp, "evaluate_predicate", lambda self, inst: masks.pop(0))
+
+    w.execute()  # diverge
+    w.execute()  # reconverge
+
+    log = sm.get_divergence_log()
+    assert sm.counters["warp_divergences"] == 2
+    assert len(log) == 2
+    first, second = log
+    assert first.warp_id == 0
+    assert first.pc == 0
+    assert first.mask_before == [True, True]
+    assert first.mask_after == [True, False]
+    assert second.mask_before == [True, False]
+    assert second.mask_after == [True, True]
+
+    sm.clear_divergence_log()
+    assert sm.get_divergence_log() == []
+    assert sm.counters["warp_divergences"] == 2

--- a/tests/test_streaming_multiprocessor.py
+++ b/tests/test_streaming_multiprocessor.py
@@ -89,7 +89,7 @@ def test_round_robin_reenqueues_active_warps():
 def test_reset_counters_and_queue():
     sm = StreamingMultiprocessor(id=0, shared_mem_size=128, max_registers_per_thread=16)
     sm.block_queue.put(DummyBlock(2))
-    sm.warp_queue.put(Warp(0, []))
+    sm.warp_queue.put(Warp(0, [], sm))
     sm.counters["warps_executed"] = 5
     sm.counters["warp_divergences"] = 2
     sm.reset()

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -6,17 +6,22 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from py_virtual_gpu.warp import Warp
 from py_virtual_gpu.thread import Thread
+from py_virtual_gpu.streaming_multiprocessor import StreamingMultiprocessor
 
 
-def test_warp_attributes_and_execute_stub():
+def test_warp_attributes_and_execute_basic(monkeypatch):
     threads = [Thread() for _ in range(3)]
-    w = Warp(id=0, threads=threads)
+    sm = StreamingMultiprocessor(id=0, shared_mem_size=0, max_registers_per_thread=0, warp_size=3)
+    w = Warp(id=0, threads=threads, sm=sm)
     assert w.id == 0
     assert len(w.threads) == 3
     assert w.active_mask == [True, True, True]
-    with pytest.raises(NotImplementedError):
-        w.execute()
     from py_virtual_gpu.dispatch import Instruction
+    monkeypatch.setattr(Warp, "fetch_next_instruction", lambda self: Instruction("NOP", tuple()))
+    monkeypatch.setattr(Warp, "evaluate_predicate", lambda self, inst: [True, True, True])
+    w.execute()
+    assert w.pc == 1
+    assert sm.counters["warp_divergences"] == 0
     inst = Instruction("NOP", tuple())
     with pytest.raises(NotImplementedError):
         w.issue_instruction(inst)


### PR DESCRIPTION
## Summary
- track divergence events via `DivergenceEvent`
- log warp divergences in `StreamingMultiprocessor`
- implement basic `Warp.execute` with divergence detection
- document divergence monitoring and provide example
- add tests for divergence logging and adapt existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857179e5c9883319847f08b7b1742e4