### PR TITLE
Implement SM warp dispatch scheduler

### DIFF
--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -8,7 +8,7 @@ O objeto `VirtualGPU` representa o dispositivo inteiro. Ele agrega diversos `Str
 
 ## StreamingMultiprocessor
 
-Cada `StreamingMultiprocessor` possui sua própria `SharedMemory` e uma fila de `ThreadBlock`s. Um SM executa os blocks de forma sequencial ou em round-robin, criando `Warp`s para conduzir as `Thread`s em *lock-step*.
+Cada `StreamingMultiprocessor` possui sua própria `SharedMemory` e uma fila de `ThreadBlock`s. Um SM executa os blocks de forma sequencial ou em round-robin, criando `Warp`s para conduzir as `Thread`s em *lock-step*. O método `dispatch()` emite uma instrução por warp a cada "ciclo" e reenfileira aqueles que continuam ativos. O contador `warps_executed` é incrementado a cada emissão.
 
 ## ThreadBlock
 

--- a/py_virtual_gpu/streaming_multiprocessor.py
+++ b/py_virtual_gpu/streaming_multiprocessor.py
@@ -72,9 +72,7 @@ class StreamingMultiprocessor:
             while not self.warp_queue.empty():
                 self.warp_queue.get()
         else:
-            self._run_round_robin()
-
-        self.counters["warps_executed"] += len(warps)
+            self.dispatch()
 
     def execute_warp(self, warp_threads: List[Thread]) -> None:
         """Conceptual lock-step execution of a warp."""
@@ -88,6 +86,7 @@ class StreamingMultiprocessor:
         """Run each warp to completion sequentially."""
         for warp in warps:
             warp.execute()
+            self.counters["warps_executed"] += 1
 
     def _run_round_robin(self) -> None:
         """Run warps in a round-robin manner until all complete."""
@@ -97,6 +96,7 @@ class StreamingMultiprocessor:
             except Exception:
                 break
             warp.execute()
+            self.counters["warps_executed"] += 1
             if any(warp.active_mask):
                 self.warp_queue.put(warp)
 
@@ -110,6 +110,7 @@ class StreamingMultiprocessor:
                 break
             inst = Instruction("NOP", tuple())
             warp.issue_instruction(inst)
+            self.counters["warps_executed"] += 1
             if any(warp.active_mask):
                 self.warp_queue.put(warp)
 

--- a/py_virtual_gpu/warp.py
+++ b/py_virtual_gpu/warp.py
@@ -47,7 +47,6 @@ class Warp:
     def issue_instruction(self, inst: Instruction) -> None:
         """Issue ``inst`` to the active threads (conceptual stub)."""
         self.pc += 1
-        raise NotImplementedError("Dispatch de instru\u00e7\u00e3o stub")
 
     def handle_divergence(self, predicate: List[bool]) -> None:
         """Handle control-flow divergence for this warp."""

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -20,22 +20,38 @@ def test_instruction_and_simtstack_basic():
     assert (mask, pc) == ([True, False], 5)
 
 
-def test_warp_issue_instruction_stub():
+def test_warp_issue_instruction_increments_pc():
     sm = StreamingMultiprocessor(id=0, shared_mem_size=0, max_registers_per_thread=0, warp_size=2)
     w = Warp(0, [Thread(), Thread()], sm)
     inst = Instruction("NOP", tuple())
-    with pytest.raises(NotImplementedError):
-        w.issue_instruction(inst)
+    w.issue_instruction(inst)
+    assert w.pc == 1
 
 
-def test_sm_dispatch_round_robin_stub():
+def test_dispatch_round_robin(monkeypatch):
     sm = StreamingMultiprocessor(id=0, shared_mem_size=8, max_registers_per_thread=4, warp_size=2)
     w1 = Warp(0, [Thread(), Thread()], sm)
     w2 = Warp(1, [Thread(), Thread()], sm)
     sm.warp_queue.put(w1)
     sm.warp_queue.put(w2)
-    with pytest.raises(NotImplementedError):
-        sm.dispatch()
+
+    counts = {0: 0, 1: 0}
+
+    def _issue(self, inst):
+        counts[self.id] += 1
+        if self.id == 0 and counts[self.id] == 1:
+            self.active_mask[0] = False
+            self.active_mask[1] = True
+        else:
+            self.active_mask = [False] * len(self.active_mask)
+
+    monkeypatch.setattr(Warp, "issue_instruction", _issue)
+    sm.dispatch()
+
+    assert counts[0] == 2
+    assert counts[1] == 1
+    assert sm.warp_queue.empty()
+    assert sm.counters["warps_executed"] == 3
 
 
 def test_sm_record_divergence_counter():
@@ -43,4 +59,23 @@ def test_sm_record_divergence_counter():
     assert sm.counters["warp_divergences"] == 0
     sm.record_divergence(Warp(0, [Thread(), Thread()], sm), 0, [True, True], [False, True])
     assert sm.counters["warp_divergences"] == 1
+
+
+def test_dispatch_sequential(monkeypatch):
+    sm = StreamingMultiprocessor(id=2, shared_mem_size=8, max_registers_per_thread=4, warp_size=2)
+    sm.schedule_policy = "sequential"
+
+    called = {"count": 0}
+
+    def _run_seq(warps):
+        called["count"] = len(warps)
+
+    monkeypatch.setattr(sm, "_run_sequential", _run_seq)
+
+    class DummyBlock:
+        def __init__(self):
+            self.threads = [Thread(), Thread(), Thread(), Thread()]
+
+    sm.execute_block(DummyBlock())
+    assert called["count"] == 2
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -23,5 +23,5 @@ def test_warp_attributes_and_execute_basic(monkeypatch):
     assert w.pc == 1
     assert sm.counters["warp_divergences"] == 0
     inst = Instruction("NOP", tuple())
-    with pytest.raises(NotImplementedError):
-        w.issue_instruction(inst)
+    w.issue_instruction(inst)
+    assert w.pc == 2


### PR DESCRIPTION
## Summary
- implement `StreamingMultiprocessor.dispatch` and update counters
- remove NotImplementedError from `Warp.issue_instruction`
- increment `warps_executed` per issued instruction
- describe dispatch behaviour in docs
- update tests for new dispatch semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68594b8979b4833187584e424b464607