### PR TITLE
Implement warp memory access profiling

### DIFF
--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -71,3 +71,19 @@ plt.xlabel("PC")
 plt.ylabel("Divergências acumuladas")
 plt.show()
 ```
+
+## Padrões de Acesso à Memória
+
+O método ``Warp.memory_access`` permite registrar se um conjunto de endereços
+é **coalescido** e se há **conflitos de banco** na ``SharedMemory``. Quando os
+endereços não são contíguos, ``counters['non_coalesced_accesses']`` é
+incrementado e ``stats['extra_cycles']`` recebe +1 ciclo conceitual. Conflitos de
+banco retornados por ``SharedMemory.detect_bank_conflicts`` aumentam
+``counters['bank_conflicts']`` e adicionam ``conflicts - 1`` ciclos extras.
+
+```python
+warp.memory_access([0, 8], 4)            # nao-coalesced
+warp.memory_access([0, 0], 4, "shared")  # conflito de banco
+print(sm.report_coalescing_stats())
+print(sm.report_bank_conflict_stats())
+```

--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -5,7 +5,7 @@ from .global_memory import GlobalMemory
 from .memory import DevicePointer
 from .streaming_multiprocessor import StreamingMultiprocessor, DivergenceEvent
 from .thread_block import ThreadBlock
-from .warp import Warp
+from .warp import Warp, is_coalesced
 from .dispatch import Instruction, SIMTStack
 from .memory_hierarchy import (
     MemorySpace,
@@ -25,6 +25,7 @@ __all__ = [
     "StreamingMultiprocessor",
     "ThreadBlock",
     "Warp",
+    "is_coalesced",
     "Instruction",
     "SIMTStack",
     "DevicePointer",

--- a/py_virtual_gpu/streaming_multiprocessor.py
+++ b/py_virtual_gpu/streaming_multiprocessor.py
@@ -45,7 +45,10 @@ class StreamingMultiprocessor:
         self.counters: Dict[str, int] = {
             "warps_executed": 0,
             "warp_divergences": 0,
+            "non_coalesced_accesses": 0,
+            "bank_conflicts": 0,
         }
+        self.stats: Dict[str, int] = {"extra_cycles": 0}
         self.divergence_log: List[DivergenceEvent] = []
 
     # ------------------------------------------------------------------
@@ -146,6 +149,25 @@ class StreamingMultiprocessor:
         self.divergence_log.clear()
 
     # ------------------------------------------------------------------
+    # Statistics reporting
+    # ------------------------------------------------------------------
+    def report_coalescing_stats(self) -> Dict[str, int]:
+        """Return current statistics for memory coalescing."""
+
+        return {
+            "non_coalesced_accesses": self.counters["non_coalesced_accesses"],
+            "extra_cycles": self.stats["extra_cycles"],
+        }
+
+    def report_bank_conflict_stats(self) -> Dict[str, int]:
+        """Return current statistics for shared memory bank conflicts."""
+
+        return {
+            "bank_conflicts": self.counters["bank_conflicts"],
+            "extra_cycles": self.stats["extra_cycles"],
+        }
+
+    # ------------------------------------------------------------------
     # Maintenance helpers
     # ------------------------------------------------------------------
     def reset(self) -> None:
@@ -154,6 +176,8 @@ class StreamingMultiprocessor:
         self.warp_queue = LocalQueue()
         for key in self.counters:
             self.counters[key] = 0
+        for key in self.stats:
+            self.stats[key] = 0
         self.divergence_log.clear()
 
     def __repr__(self) -> str:  # pragma: no cover - debugging helper

--- a/tests/test_memory_coalescing.py
+++ b/tests/test_memory_coalescing.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.warp import Warp, is_coalesced
+from py_virtual_gpu.shared_memory import SharedMemory
+from py_virtual_gpu.thread import Thread
+from py_virtual_gpu.streaming_multiprocessor import StreamingMultiprocessor
+
+
+def test_is_coalesced_true():
+    assert is_coalesced([0, 4, 8, 12], 4) is True
+
+
+def test_is_coalesced_false():
+    assert is_coalesced([0, 8, 20, 32], 4) is False
+
+
+def test_detect_bank_conflicts():
+    sm = SharedMemory(64, num_banks=4, bank_stride=4)
+    addrs = [0, 4, 8, 0]
+    assert sm.detect_bank_conflicts(addrs) == 1
+
+
+def test_warp_memory_access_updates_counters():
+    sm = StreamingMultiprocessor(id=0, shared_mem_size=64, max_registers_per_thread=0, warp_size=2)
+    w = Warp(0, [Thread(), Thread()], sm)
+
+    w.memory_access([0, 8], 4)
+    assert sm.counters["non_coalesced_accesses"] == 1
+    assert sm.stats["extra_cycles"] == 1
+
+    w.memory_access([0, 0], 4, space="shared")
+    assert sm.counters["bank_conflicts"] == 1
+    assert sm.stats["extra_cycles"] == 2


### PR DESCRIPTION
## Summary
- track coalescing and bank conflicts in `StreamingMultiprocessor`
- add `Warp.memory_access` and helper `is_coalesced`
- extend `SharedMemory` with bank conflict detection
- document new statistics
- add tests for coalescing logic and conflict counters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859716e0cc08331a5b02352d638ed35