### PR TITLE
Implement register spilling with LocalMemory

### DIFF
--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -87,3 +87,12 @@ warp.memory_access([0, 0], 4, "shared")  # conflito de banco
 print(sm.report_coalescing_stats())
 print(sm.report_bank_conflict_stats())
 ```
+
+## Spill de Registradores
+
+Quando uma thread excede a capacidade de seu ``RegisterFile`` durante uma
+escrita, os bytes extras são redirecionados para sua ``LocalMemory`` privada.
+Cada spill registra eventos e adiciona ciclos extras calculados a partir de
+``spill_granularity`` e ``spill_latency_cycles``. As estatísticas podem ser
+obtidas por thread com ``thread.get_spill_stats()`` ou agregadas pela
+``VirtualGPU.get_memory_stats()``.

--- a/tests/test_memory_hierarchy.py
+++ b/tests/test_memory_hierarchy.py
@@ -27,16 +27,30 @@ def test_stats_account_and_reset():
     rf.read(0, 50)
     cycles = rf.latency_cycles + math.ceil(100 / rf.bandwidth_bpc)
     cycles += rf.latency_cycles + math.ceil(50 / rf.bandwidth_bpc)
-    assert rf.stats == {"reads": 1, "writes": 1, "cycles": cycles}
+    assert rf.stats == {
+        "reads": 1,
+        "writes": 1,
+        "cycles": cycles,
+        "spill_events": 0,
+        "spill_bytes": 0,
+        "spill_cycles": 0,
+    }
     rf.reset_stats()
-    assert rf.stats == {"reads": 0, "writes": 0, "cycles": 0}
+    assert rf.stats == {
+        "reads": 0,
+        "writes": 0,
+        "cycles": 0,
+        "spill_events": 0,
+        "spill_bytes": 0,
+        "spill_cycles": 0,
+    }
 
 
 def test_bounds_checks():
     rf = RegisterFile(32)
     with pytest.raises(IndexError):
         rf.read(16, 20)
-    with pytest.raises(IndexError):
+    with pytest.raises(RuntimeError):
         rf.write(20, b"\x00" * 20)
     sm = SharedMemory(64)
     with pytest.raises(IndexError):

--- a/tests/test_spill_registers.py
+++ b/tests/test_spill_registers.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from unittest import mock
+import math
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.thread import Thread
+
+
+def test_no_spill_when_within_capacity():
+    t = Thread(register_mem_size=8)
+    t.registers.write(0, b"abcd")
+    assert t.get_spill_stats() == {"spill_events": 0, "spill_bytes": 0, "spill_cycles": 0}
+    assert t.local_mem.stats["writes"] == 0
+
+
+def test_spill_exact_overflow():
+    t = Thread(register_mem_size=8)
+    with mock.patch.object(t.local_mem, "write", wraps=t.local_mem.write) as w:
+        t.registers.write(0, b"abcdefghij")
+        assert w.call_count == 1
+    assert t.registers.read(0, 8) == b"abcdefgh"
+    assert t.local_mem.read(0, 2) == b"ij"
+    stats = t.get_spill_stats()
+    assert stats["spill_events"] == 1
+    assert stats["spill_bytes"] == 2
+    assert stats["spill_cycles"] == 50
+
+
+def test_multiple_spill_events():
+    t = Thread(register_mem_size=8)
+    with mock.patch.object(t.local_mem, "write", wraps=t.local_mem.write) as w:
+        t.registers.write(0, b"AAAAAA")  # fits
+        t.registers.write(6, b"BBBB")    # 2 spill
+        t.registers.write(10, b"CCCCC")  # 5 spill
+        assert w.call_count == 2
+    assert t.local_mem.read(0, 2) == b"BB"
+    assert t.local_mem.read(2, 5) == b"CCCCC"
+    stats = t.get_spill_stats()
+    assert stats["spill_events"] == 2
+    assert stats["spill_bytes"] == 7
+    expected_cycles = math.ceil(2/4)*50 + math.ceil(5/4)*50
+    assert stats["spill_cycles"] == expected_cycles

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -4,17 +4,16 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from py_virtual_gpu.thread import Thread, RegisterMemory
+from py_virtual_gpu.thread import Thread
+from py_virtual_gpu.memory_hierarchy import RegisterFile
 from py_virtual_gpu.shared_memory import SharedMemory
 from py_virtual_gpu.global_memory import GlobalMemory
 
 
-def test_register_memory_read_write_clear():
-    rm = RegisterMemory(1024)
-    rm.write("a", 123)
-    assert rm.read("a") == 123
-    rm.clear()
-    assert rm.read("a") is None
+def test_register_file_read_write():
+    rf = RegisterFile(16)
+    rf.write(0, b"abcd")
+    assert rf.read(0, 4) == b"abcd"
 
 
 def test_thread_attributes():
@@ -25,7 +24,7 @@ def test_thread_attributes():
     assert t.block_idx == (1, 2, 3)
     assert t.block_dim == (4, 4, 1)
     assert t.grid_dim == (8, 8, 1)
-    assert isinstance(t.registers, RegisterMemory)
+    assert isinstance(t.registers, RegisterFile)
     assert t.registers.size == 256
 
 


### PR DESCRIPTION
## Summary
- add spilling semantics to `RegisterFile` and latency accounting
- allocate `LocalMemory` inside `Thread` and expose spill stats
- store blocks in `VirtualGPU` and aggregate spill metrics
- document register spill behaviour
- update memory hierarchy tests and add dedicated spill tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599834fb248331b253bae5404c6e67