### PR TITLE
Implement PCIe transfer metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,8 @@ def hello(threadIdx, blockIdx, blockDim, gridDim, msg):
 hello("Oi")
 
 ptr = gpu.malloc(4)
-gpu.memcpy_host_to_device(ptr, b"data", 4)
-buf = bytearray(4)
-gpu.memcpy_device_to_host(buf, ptr, 4)
-print(bytes(buf))
+gpu.memcpy_host_to_device(b"data", ptr)
+data = gpu.memcpy_device_to_host(ptr, 4)
+print(data)
 gpu.free(ptr)
 ```

--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -45,6 +45,12 @@ específicos como ``ConstantMemory`` e ``LocalMemory``. O método
 
 - `VirtualGPU.malloc` e `VirtualGPU.free` permitem gerenciar espacos em `GlobalMemory` por meio de `DevicePointer`.
 - `memcpy_host_to_device`, `memcpy_device_to_host` e `memcpy` copiam dados entre CPU e GPU.
+- Exemplo de cópia:
+```python
+ptr = gpu.malloc(256)
+gpu.memcpy_host_to_device(b"\x00" * 256, ptr)
+data = gpu.memcpy_device_to_host(ptr, 256)
+```
 - O decorador `@kernel` transforma funcoes Python em kernels e utiliza o dispositivo definido por `VirtualGPU.set_current`.
 - `launch_kernel` divide o grid em `ThreadBlock`s e distribui entre os SMs, expondo `threadIdx`, `blockIdx`, `blockDim` e `gridDim` para o kernel.
 - `ThreadBlock.barrier_sync()` permite que as threads de um block aguardem umas

--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -7,6 +7,7 @@ from .streaming_multiprocessor import StreamingMultiprocessor, DivergenceEvent
 from .thread_block import ThreadBlock
 from .warp import Warp, is_coalesced
 from .dispatch import Instruction, SIMTStack
+from .transfer import TransferEvent
 from .memory_hierarchy import (
     MemorySpace,
     RegisterFile,
@@ -39,5 +40,6 @@ __all__ = [
     "ConstantMemory",
     "LocalMemory",
     "HostMemory",
+    "TransferEvent",
 ]
 

--- a/py_virtual_gpu/global_memory.py
+++ b/py_virtual_gpu/global_memory.py
@@ -15,13 +15,20 @@ from typing import Dict, List, Tuple
 class GlobalMemory:
     """Simulated global memory accessible to all thread blocks."""
 
-    def __init__(self, size: int) -> None:
+    def __init__(
+        self,
+        size: int,
+        latency_cycles: int = 200,
+        bandwidth_bytes_per_cycle: int = 32,
+    ) -> None:
         """Create a block of ``size`` bytes backed by shared memory."""
         self.size: int = size
         self.buffer = Array(c_byte, size, lock=False)
         self.lock = Lock()
         self.allocations: Dict[int, int] = {}
         self._free_list: List[Tuple[int, int]] = [(0, size)]
+        self.latency_cycles = latency_cycles
+        self.bandwidth_bpc = bandwidth_bytes_per_cycle
 
     # ------------------------------------------------------------------
     # Allocation helpers

--- a/py_virtual_gpu/memory_hierarchy.py
+++ b/py_virtual_gpu/memory_hierarchy.py
@@ -246,11 +246,43 @@ class LocalMemory(MemorySpace):
 
 
 class HostMemory(MemorySpace):
-    """Memory residing on the host side."""
+    """Memory residing on the host side.
 
-    def __init__(self, size: int = 0, latency_cycles: int = 1000, bandwidth_bytes_per_cycle: int = 16) -> None:
+    Parameters
+    ----------
+    size:
+        Capacity of the simulated host memory.
+    latency_cycles:
+        Base latency for host reads/writes.
+    bandwidth_bytes_per_cycle:
+        Effective bandwidth in bytes per cycle for host accesses.
+    latency_cycles_host_to_device:
+        Latency used when copying data to a device memory space. Defaults to
+        ``latency_cycles`` when ``None``.
+    bandwidth_bpc_host_to_device:
+        Bandwidth in bytes per cycle for host-to-device transfers. Defaults to
+        ``bandwidth_bytes_per_cycle`` when ``None``.
+    """
+
+    def __init__(
+        self,
+        size: int = 0,
+        latency_cycles: int = 1000,
+        bandwidth_bytes_per_cycle: int = 16,
+        *,
+        latency_cycles_host_to_device: int | None = None,
+        bandwidth_bpc_host_to_device: int | None = None,
+    ) -> None:
         super().__init__(size, latency_cycles, bandwidth_bytes_per_cycle)
         self.buffer = bytearray(self.size)
+        self.latency_cycles_host_to_device = (
+            latency_cycles if latency_cycles_host_to_device is None else latency_cycles_host_to_device
+        )
+        self.bandwidth_bpc_host_to_device = (
+            bandwidth_bytes_per_cycle
+            if bandwidth_bpc_host_to_device is None
+            else bandwidth_bpc_host_to_device
+        )
 
     def read(self, offset: int, size: int) -> bytes:
         if offset < 0 or offset + size > self.size:

--- a/py_virtual_gpu/transfer.py
+++ b/py_virtual_gpu/transfer.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["TransferEvent"]
+
+@dataclass
+class TransferEvent:
+    """Record a host<->device memory copy."""
+
+    direction: str  # "H2D" or "D2H"
+    size: int
+    start_cycle: int
+    end_cycle: int

--- a/tests/test_host_device_transfers.py
+++ b/tests/test_host_device_transfers.py
@@ -1,0 +1,31 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from py_virtual_gpu import VirtualGPU, DevicePointer
+
+
+def test_h2d_and_d2h_identity():
+    gpu = VirtualGPU(0, 512)
+    ptr = gpu.malloc(64)
+    data = bytes(range(64))
+    gpu.memcpy_host_to_device(data, ptr)
+    out = gpu.memcpy_device_to_host(ptr, 64)
+    assert out == data
+
+
+def test_transfer_metrics():
+    gpu = VirtualGPU(
+        0,
+        256,
+        host_latency_cycles=5,
+        host_bandwidth_bpc=64,
+        device_latency_cycles=5,
+        device_bandwidth_bpc=64,
+    )
+    ptr = gpu.malloc(128)
+    gpu.memcpy_host_to_device(b"a" * 128, ptr)
+    gpu.memcpy_device_to_host(ptr, 128)
+    stats = gpu.get_transfer_stats()
+    assert stats["transfers"] == 2
+    assert stats["transfer_bytes"] == 256
+    assert stats["transfer_cycles"] == 14  # 7 cycles each

--- a/tests/test_virtualgpu_memory.py
+++ b/tests/test_virtualgpu_memory.py
@@ -63,11 +63,10 @@ def test_memcpy_host_to_device_and_back():
     gpu = VirtualGPU(0, 32)
     host_buf = bytes(range(8))
     ptr = gpu.malloc(8)
-    gpu.memcpy_host_to_device(ptr, host_buf, 8)
+    gpu.memcpy_host_to_device(host_buf, ptr)
     assert gpu.global_memory.read(ptr.offset, 8) == host_buf
 
-    out = bytearray(8)
-    gpu.memcpy_device_to_host(out, ptr, 8)
+    out = gpu.memcpy_device_to_host(ptr, 8)
     assert out == host_buf
 
 
@@ -76,12 +75,12 @@ def test_memcpy_validation_errors():
     ptr = gpu.malloc(4)
 
     with pytest.raises(ValueError):
-        gpu.memcpy_host_to_device(ptr, b"\x00\x01", 4)
+        gpu.memcpy_host_to_device(b"\x00\x01", ptr)
 
     with pytest.raises(ValueError):
-        gpu.memcpy_device_to_host(bytearray(2), ptr, 4)
+        gpu.memcpy_device_to_host(ptr, -1)
 
     gpu.free(ptr)
     with pytest.raises(ValueError):
-        gpu.memcpy_host_to_device(ptr, b"abcd", 4)
+        gpu.memcpy_host_to_device(b"abcd", ptr)
 


### PR DESCRIPTION
## Summary
- model host-device transfers with latency/bandwidth accounting
- add `TransferEvent` dataclass
- record metrics and expose via `get_transfer_stats()`
- document explicit memory copy usage
- test host↔device transfers and metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b0e91cd4833196ee4beb5c61621b