### PR TITLE
Add constant memory read helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ O `VirtualGPU` distribui blocks para os SMs, que por sua vez instanciam warps e 
 - Copias entre host e dispositivo por `memcpy_host_to_device` e `memcpy_device_to_host`.
 - Decorador `@kernel` que permite executar funcoes Python como kernels.
 - Lançamento de kernel via `launch_kernel` com exposicao de `threadIdx` e `blockIdx`.
+- Memoria constante (`64 KiB` por padrao) acessivel por
+  `gpu = VirtualGPU.get_current(); gpu.read_constant(...)` ou `thread.const_mem.read(...)`.
 
 ## Exemplo rapido
 
@@ -54,4 +56,8 @@ gpu.memcpy_host_to_device(b"data", ptr)
 data = gpu.memcpy_device_to_host(ptr, 4)
 print(data)
 gpu.free(ptr)
+
+# Leitura de memoria constante
+gpu.set_constant(b"abc")
+print(gpu.read_constant(0, 3))
 ```

--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -29,7 +29,11 @@ Os diferentes níveis da hierarquia são representados por subclasses de
 acumuladas nos campos ``stats`` sempre que ``read`` ou ``write`` são chamados.
 Entre elas estão ``RegisterFile`` (registradores privados), ``SharedMemory``
 (on-chip), ``L1Cache`` e ``L2Cache`` (caches), ``GlobalMemorySpace`` e espaços
-específicos como ``ConstantMemory`` e ``LocalMemory``. O método
+específicos como ``ConstantMemory`` e ``LocalMemory``. ``ConstantMemory`` é uma
+região de somente leitura com tamanho padrão de ``64 KiB`` acessível a todas as
+threads. Um kernel pode obter esses dados via ``gpu = VirtualGPU.get_current();
+gpu.read_constant(addr, size)`` ou diretamente por ``thread.const_mem.read``.
+O método
 ``reset_stats()`` permite zerar os contadores para novas medições.
 
 ## Fluxo de Execução

--- a/py_virtual_gpu/virtualgpu.py
+++ b/py_virtual_gpu/virtualgpu.py
@@ -214,6 +214,16 @@ class VirtualGPU:
         self.counters["transfers"] += 1
         self.transfer_log.append(TransferEvent("H2D", len(data), start, start + cycles))
 
+    def read_constant(self, addr: int, size: int) -> bytes:
+        """Return ``size`` bytes starting at ``addr`` from constant memory.
+
+        This is a convenience wrapper around :meth:`ConstantMemory.read`
+        so that kernels can call ``VirtualGPU.get_current().read_constant``
+        instead of accessing ``thread.const_mem`` directly.
+        """
+
+        return self.const_memory.read(addr, size)
+
     def launch_kernel(
         self,
         kernel_func: Callable[..., Any],

--- a/tests/test_constant_memory.py
+++ b/tests/test_constant_memory.py
@@ -38,3 +38,9 @@ def test_launch_kernel_exposes_const_mem():
     t = tb.threads[0]
     assert t.const_mem is gpu.const_memory
 
+
+def test_read_constant_wrapper():
+    gpu = VirtualGPU(0, 32)
+    gpu.set_constant(b"xyz")
+    assert gpu.read_constant(0, 3) == b"xyz"
+


### PR DESCRIPTION
## Summary
- add `VirtualGPU.read_constant` wrapper
- document constant memory usage and default size
- show constant memory example in README
- test the wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2e6865bc8331bb958b7fbb25ce65