### PR TITLE
Add per-thread local memory allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Simulador em Python de uma arquitetura de GPU para estudos de paralelismo e prog
 - **StreamingMultiprocessor** – executa `ThreadBlock`s e gerencia `Warp`s.
 - **ThreadBlock** – conjunto de threads com `SharedMemory` e barreira de sincronização.
 - **Thread/Warp** – threads são agrupadas em warps que executam em *lock-step*.
-- **Memórias** – `GlobalMemory` compartilhada por todos os blocks e `SharedMemory` restrita a cada block.
+- **Memórias** – `GlobalMemory` compartilhada por todos os blocks, `SharedMemory` restrita a cada block e `LocalMemory` privada por thread para variáveis grandes e spill de registradores.
 
 Um resumo detalhado das classes está em [docs/class_structure.md](docs/class_structure.md). Para uma descrição do fluxo de execução consulte [docs/components_and_execution.md](docs/components_and_execution.md).
 
@@ -36,6 +36,7 @@ O `VirtualGPU` distribui blocks para os SMs, que por sua vez instanciam warps e 
 - Lançamento de kernel via `launch_kernel` com exposicao de `threadIdx` e `blockIdx`.
 - Memoria constante (`64 KiB` por padrao) acessivel por
   `gpu = VirtualGPU.get_current(); gpu.read_constant(...)` ou `thread.const_mem.read(...)`.
+- `Thread.alloc_local(size)` permite reservar bytes em `LocalMemory` para variáveis locais grandes do kernel.
 
 ## Exemplo rapido
 

--- a/docs/class_structure.md
+++ b/docs/class_structure.md
@@ -48,10 +48,12 @@ A implementação detalhada destas classes e de suas APIs será tratada nas **is
 
 **Principais atributos**
 - `registers`: memória privada de cada thread.
+- `local_mem`: área de `LocalMemory` para variáveis locais grandes e spill de registradores.
 - `thread_idx` e `block_idx`: índices que identificam a posição desta thread no grid.
 
 **Métodos principais**
 - `execute(kernel_func, *args)`: executa a função do kernel com os argumentos fornecidos.
+- `alloc_local(size)`: reserva espaço em `local_mem` para uso do kernel.
 - `read_write_memory(...)`: operações utilitárias para acessar a memória global ou compartilhada conforme necessário.
 
 

--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -106,3 +106,10 @@ Cada spill registra eventos e adiciona ciclos extras calculados a partir de
 ``spill_granularity`` e ``spill_latency_cycles``. As estatísticas podem ser
 obtidas por thread com ``thread.get_spill_stats()`` ou agregadas pela
 ``VirtualGPU.get_memory_stats()``.
+
+## Memória Local por Thread
+
+Variáveis locais que não cabem nos registradores podem ser alocadas na
+``LocalMemory`` de cada thread. O método ``Thread.alloc_local(size)``
+retorna o deslocamento reservado nessa região para ser usado pelo kernel.
+Seu acesso possui a mesma latência e largura de banda da ``GlobalMemory``.

--- a/py_virtual_gpu/thread_block.py
+++ b/py_virtual_gpu/thread_block.py
@@ -46,7 +46,13 @@ class ThreadBlock:
     # ------------------------------------------------------------------
     # Thread management
     # ------------------------------------------------------------------
-    def initialize_threads(self, kernel_func: Callable[..., Any], *args: Any) -> None:
+    def initialize_threads(
+        self,
+        kernel_func: Callable[..., Any],
+        *args: Any,
+        register_mem_size: int = 0,
+        local_mem_size: int | None = None,
+    ) -> None:
         """Instantiate :class:`Thread` objects for this block.
 
         Each created :class:`Thread` receives references to this block's
@@ -59,7 +65,10 @@ class ThreadBlock:
             for y in range(self.block_dim[1]):
                 for x in range(self.block_dim[0]):
                     thread_idx = (x, y, z)
-                    t = Thread()
+                    t = Thread(
+                        register_mem_size=register_mem_size,
+                        local_mem_size=local_mem_size,
+                    )
                     # Store context attributes for future use
                     setattr(t, "thread_idx", thread_idx)
                     setattr(t, "block_idx", self.block_idx)

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -70,3 +70,21 @@ def test_repr_contains_indices_and_register_count():
     assert "blk=(0,0,0)" in text
     assert "regs=0" in text
 
+
+def test_alloc_local_and_latency():
+    gm = GlobalMemory(16)
+    t = Thread(register_mem_size=4, local_mem_size=8)
+    off1 = t.alloc_local(4)
+    off2 = t.alloc_local(2)
+    assert (off1, off2) == (0, 4)
+    assert t.local_ptr == 6
+    assert t.local_mem.latency_cycles == gm.latency_cycles
+    assert t.local_mem.bandwidth_bpc == gm.bandwidth_bpc
+
+
+def test_alloc_local_overflow():
+    t = Thread(register_mem_size=4, local_mem_size=4)
+    t.alloc_local(4)
+    with pytest.raises(MemoryError):
+        t.alloc_local(1)
+

--- a/tests/test_thread_block.py
+++ b/tests/test_thread_block.py
@@ -94,3 +94,11 @@ def test_barrier_wait_orders_entries():
     assert len(before_indices) == total_threads
     assert len(after_indices) == total_threads
     assert min(after_indices) > max(before_indices)
+
+
+def test_initialize_threads_custom_register_and_local_size():
+    tb = ThreadBlock((0, 0, 0), (2, 1, 1), (1, 1, 1), shared_mem_size=0)
+    tb.initialize_threads(lambda *a: None, register_mem_size=8, local_mem_size=16)
+    for t in tb.threads:
+        assert t.registers.size == 8
+        assert t.local_mem.size == 16


### PR DESCRIPTION
## Summary
- introduce `local_ptr` and `alloc_local` in `Thread`
- allow `ThreadBlock.initialize_threads` to pass register/local memory sizes
- document LocalMemory usage for large local variables
- extend docs about thread local memory
- test new allocation behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b34c8fd748331a22a945a10557340