### PR TITLE
Add local memory kernel tests and update alloc_local

### DIFF
--- a/py_virtual_gpu/thread.py
+++ b/py_virtual_gpu/thread.py
@@ -112,7 +112,7 @@ class Thread:
         """Reserve ``size`` bytes in ``LocalMemory`` and return the offset."""
 
         if self.local_ptr + size > self.local_mem.size:
-            raise MemoryError("Out of LocalMemory")
+            raise IndexError("Out of LocalMemory")
         off = self.local_ptr
         self.local_ptr += size
         return off

--- a/tests/test_local_memory.py
+++ b/tests/test_local_memory.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import math
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.thread import Thread
+
+
+def _kernel_alloc_write(threadIdx, blockIdx, blockDim, gridDim, th, data):
+    off = th.alloc_local(len(data))
+    th.local_mem.write(off, data)
+    return off
+
+
+def test_kernel_alloc_persistence_and_latency():
+    t = Thread(register_mem_size=0, local_mem_size=16)
+    data = b"abcd"
+    off = t.run(
+        _kernel_alloc_write,
+        t.thread_idx,
+        t.block_idx,
+        t.block_dim,
+        t.grid_dim,
+        t,
+        data,
+    )
+    stats = dict(t.local_mem.stats)
+    assert off == 0
+    assert t.local_ptr == len(data)
+    assert t.local_mem.read(off, len(data)) == data
+    expected_cycles = t.local_mem.latency_cycles + math.ceil(len(data) / t.local_mem.bandwidth_bpc)
+    assert stats == {"reads": 0, "writes": 1, "cycles": expected_cycles}
+
+
+def _kernel_overflow(threadIdx, blockIdx, blockDim, gridDim, th):
+    th.alloc_local(4)
+    th.alloc_local(4)
+    th.alloc_local(1)
+
+
+def test_alloc_local_overflow_inside_kernel():
+    t = Thread(register_mem_size=0, local_mem_size=8)
+    with pytest.raises(IndexError):
+        t.run(
+            _kernel_overflow,
+            t.thread_idx,
+            t.block_idx,
+            t.block_dim,
+            t.grid_dim,
+            t,
+        )

--- a/tests/test_thread.py
+++ b/tests/test_thread.py
@@ -85,6 +85,6 @@ def test_alloc_local_and_latency():
 def test_alloc_local_overflow():
     t = Thread(register_mem_size=4, local_mem_size=4)
     t.alloc_local(4)
-    with pytest.raises(MemoryError):
+    with pytest.raises(IndexError):
         t.alloc_local(1)
 


### PR DESCRIPTION
## Summary
- ensure `Thread.alloc_local` raises `IndexError` on overflow
- update existing thread tests for the new exception
- add tests covering local memory allocation inside a kernel

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd4086bbc833180a57db876bac90a