### PR TITLE
Expand docs about constant and local memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ graph TD
 
 O `VirtualGPU` distribui blocks para os SMs, que por sua vez instanciam warps e threads para executar o kernel.
 
+## Hierarquia de Memória
+
+Registradores, `SharedMemory`, `LocalMemory`, `ConstantMemory` e `GlobalMemory` são modelados com latências conceituais. Dados constantes podem ser carregados com `gpu.set_constant`:
+
+```python
+gpu.set_constant(b"valores")
+```
+
 
 ## Funcionalidades
 

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -96,6 +96,7 @@ Para auxiliar na compreensão e na implementação, a Tabela 1 resume as caracte
 | **Memória Constante**     | Global (somente leitura)             | *Off-chip*        | Baixa (*cached*)    | Alta (*cached*)             | KB (ex: ~64KB)              | Dados de transmissão somente leitura                         |
 | **Memória Global**        | Global (todas as *threads*/*blocks*) | *Off-chip*        | Alta                | Moderada                    | GB (ex: ~32GB)              | Grandes conjuntos de dados, comunicação entre *blocks*       |
 | **Memória do Host**       | Sistema CPU                          | *Off-device*      | Muito Alta          | Variável                    | GB (RAM do sistema)         | Dados gerenciados pela CPU, I/O                              |
+A implementacao atual inclui classes para ``ConstantMemory`` e ``LocalMemory``, permitindo carregar dados constantes e alocar memoria privada por thread.
 
 
 


### PR DESCRIPTION
## Summary
- detail ConstantMemory and LocalMemory in docs with code examples
- add memory hierarchy section to README showing how to load constants
- note implementation of ConstantMemory and LocalMemory in research document

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd409665c833180a55cf54ec9f214