### PR TITLE
Implement global memory atomic helpers

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -8,6 +8,14 @@ from .thread_block import ThreadBlock
 from .warp import Warp, is_coalesced
 from .dispatch import Instruction, SIMTStack
 from .transfer import TransferEvent
+from .atomics import (
+    atomicAdd,
+    atomicSub,
+    atomicCAS,
+    atomicMax,
+    atomicMin,
+    atomicExchange,
+)
 from .memory_hierarchy import (
     MemorySpace,
     RegisterFile,
@@ -44,5 +52,11 @@ __all__ = [
     "LocalMemory",
     "HostMemory",
     "TransferEvent",
+    "atomicAdd",
+    "atomicSub",
+    "atomicCAS",
+    "atomicMax",
+    "atomicMin",
+    "atomicExchange",
 ]
 

--- a/py_virtual_gpu/atomics.py
+++ b/py_virtual_gpu/atomics.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from .virtualgpu import VirtualGPU
+from .memory import DevicePointer
+
+
+def atomicAdd(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
+    """Atomically add ``value`` to integer at ``ptr`` in global memory."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_add(ptr.offset, value, num_bytes)
+
+
+def atomicSub(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
+    """Atomically subtract ``value`` from integer at ``ptr``."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_sub(ptr.offset, value, num_bytes)
+
+
+def atomicCAS(ptr: DevicePointer, expected: int, new: int, num_bytes: int = 4) -> bool:
+    """Compare-and-swap integer at ``ptr``."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_cas(ptr.offset, expected, new, num_bytes)
+
+
+def atomicMax(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
+    """Atomically store ``max(current, value)`` at ``ptr``."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_max(ptr.offset, value, num_bytes)
+
+
+def atomicMin(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
+    """Atomically store ``min(current, value)`` at ``ptr``."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_min(ptr.offset, value, num_bytes)
+
+
+def atomicExchange(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
+    """Atomically exchange value at ``ptr`` and return old value."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_exchange(ptr.offset, value, num_bytes)
+
+
+__all__ = [
+    "atomicAdd",
+    "atomicSub",
+    "atomicCAS",
+    "atomicMax",
+    "atomicMin",
+    "atomicExchange",
+]


### PR DESCRIPTION
## Summary
- add `py_virtual_gpu/atomics.py` with wrappers for global memory atomics
- expose the new functions through `py_virtual_gpu.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be9c9a7cc83318afd9a9328c09938