### PR TITLE
Add docs for atomic helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,19 @@ gpu.set_constant(b"valores")
 - Ponteiros retornados por `malloc` são objetos `DevicePointer` e agora aceitam
   aritmética e indexação (`ptr + n`, `ptr[i]`, etc.), imitando a sintaxe do
   CUDA C++.
+- Funcoes `atomicAdd`, `atomicSub`, `atomicCAS`, `atomicMax`, `atomicMin` e `atomicExchange` realizam operacoes atomicas sobre `DevicePointer`. Os mesmos metodos continuam disponiveis em `SharedMemory` e `GlobalMemory`.
+### Operacoes Atomicas
+
+```python
+from py_virtual_gpu import kernel, atomicAdd
+
+@kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
+def incr(threadIdx, blockIdx, blockDim, gridDim, counter_ptr):
+    atomicAdd(counter_ptr, 1)
+```
 
 ## Exemplo rapido
+
 
 ```python
 from py_virtual_gpu import VirtualGPU, kernel

--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -84,6 +84,22 @@ def vec_mul(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):
 - A classe `SharedMemory` expõe operações atômicas (`atomic_add`, `atomic_sub`,
   `atomic_cas`, `atomic_max`, `atomic_min`, `atomic_exchange`) que permitem
   atualização segura de valores compartilhados entre threads.
+## Operações Atômicas
+
+A biblioteca também fornece *helpers* de alto nível para realizar operações atômicas diretamente sobre ``DevicePointer`` na ``GlobalMemory``. As funções ``atomicAdd``, ``atomicSub``, ``atomicCAS``, ``atomicMax``, ``atomicMin`` e ``atomicExchange`` recebem o ponteiro e o valor desejado, retornando o valor anterior.
+
+```python
+from py_virtual_gpu import kernel, atomicAdd
+
+@kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
+def incr(threadIdx, blockIdx, blockDim, gridDim, counter_ptr):
+    atomicAdd(counter_ptr, 1)
+```
+
+Esses *helpers* utilizam internamente ``GlobalMemory.atomic_*``. Os métodos
+originais continuam acessíveis diretamente através das instâncias de
+``SharedMemory`` e ``GlobalMemory``.
+
 
 ## Monitoramento de Divergência
 


### PR DESCRIPTION
## Summary
- document new atomic* helpers in components_and_execution.md and README
- show an example kernel using atomicAdd
- note that atomic methods are still available via memory objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685beb7c586883319de6f65a3f4f8429