### PR TITLE
Add example scripts for vector multiplication and 2D convolution

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Example Scripts
+
+This directory contains small demonstrations using the virtual GPU simulator.
+
+## Running
+
+Execute the scripts directly with Python:
+
+```bash
+python examples/vector_mul.py
+python examples/convolution_2d.py
+```
+
+Each program allocates memory on the virtual device, launches a kernel and prints
+whether the result computed on the device matches the host computation.

--- a/examples/convolution_2d.py
+++ b/examples/convolution_2d.py
@@ -1,0 +1,98 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU
+from py_virtual_gpu.thread_block import ThreadBlock
+
+
+def conv2d_kernel(threadIdx, blockIdx, blockDim, gridDim,
+                  in_ptr, out_ptr, width, height,
+                  shared_mem, barrier):
+    tx, ty, _ = threadIdx
+    idx = ty * width + tx
+    # load element to shared memory
+    val = int.from_bytes(in_ptr[idx], "little", signed=True)
+    shared_mem.write(idx * 4, val.to_bytes(4, "little", signed=True))
+    barrier.wait()
+
+    if 0 < tx < width - 1 and 0 < ty < height - 1:
+        acc = 0
+        for j in range(3):
+            for i in range(3):
+                coeff_bytes = VirtualGPU.get_current().read_constant((j * 3 + i) * 4, 4)
+                coeff = int.from_bytes(coeff_bytes, "little", signed=True)
+                sx = tx + i - 1
+                sy = ty + j - 1
+                s_idx = sy * width + sx
+                val = int.from_bytes(shared_mem.read(s_idx * 4, 4), "little", signed=True)
+                acc += val * coeff
+        out_ptr[idx] = acc.to_bytes(4, "little", signed=True)
+    else:
+        out_ptr[idx] = (0).to_bytes(4, "little", signed=True)
+
+
+def host_convolution(inp, kernel):
+    h = len(inp)
+    w = len(inp[0])
+    pad = len(kernel) // 2
+    out = [[0 for _ in range(w)] for _ in range(h)]
+    for y in range(h):
+        for x in range(w):
+            if pad <= x < w - pad and pad <= y < h - pad:
+                acc = 0
+                for j in range(len(kernel)):
+                    for i in range(len(kernel[0])):
+                        acc += inp[y + j - pad][x + i - pad] * kernel[j][i]
+                out[y][x] = acc
+    return out
+
+
+def main() -> None:
+    width = height = 4
+    gpu = VirtualGPU(num_sms=0, global_mem_size=256)
+    VirtualGPU.set_current(gpu)
+
+    input_matrix = [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+    ]
+    kernel = [
+        [1, 0, 1],
+        [0, 1, 0],
+        [1, 0, 1],
+    ]
+    filter_flat = [v for row in kernel for v in row]
+    const_data = b"".join(int(v).to_bytes(4, "little", signed=True) for v in filter_flat)
+    gpu.set_constant(const_data)
+
+    in_bytes = b"".join(int(v).to_bytes(4, "little", signed=True) for row in input_matrix for v in row)
+    in_ptr = gpu.malloc(len(in_bytes))
+    out_ptr = gpu.malloc(len(in_bytes))
+    gpu.memcpy_host_to_device(in_bytes, in_ptr)
+
+    tb = ThreadBlock((0, 0, 0), (width, height, 1), (1, 1, 1), shared_mem_size=len(in_bytes))
+    tb.initialize_threads(conv2d_kernel)
+    for t in tb.threads:
+        setattr(t, "global_mem", gpu.global_memory)
+        setattr(t, "const_mem", gpu.const_memory)
+    tb.execute(conv2d_kernel, in_ptr, out_ptr, width, height, tb.shared_mem, tb.barrier)
+
+    out = gpu.memcpy_device_to_host(out_ptr, len(in_bytes))
+    result = [int.from_bytes(out[i * 4:(i + 1) * 4], "little", signed=True) for i in range(width * height)]
+    expected_matrix = host_convolution(input_matrix, kernel)
+    expected = [v for row in expected_matrix for v in row]
+
+    print("Kernel result:", result)
+    print("Host result:", expected)
+    if result == expected:
+        print("2D convolution successful!")
+    else:
+        print("Mismatch detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vector_mul.py
+++ b/examples/vector_mul.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU
+from py_virtual_gpu.kernel import kernel
+
+
+@kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
+def vec_mul(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):
+    i = threadIdx[0]
+    a = int.from_bytes(a_ptr[i], "little", signed=True)
+    b = int.from_bytes(b_ptr[i], "little", signed=True)
+    out_ptr[i] = (a * b).to_bytes(4, "little", signed=True)
+
+
+def main() -> None:
+    gpu = VirtualGPU(num_sms=0, global_mem_size=64)
+    VirtualGPU.set_current(gpu)
+
+    a_vals = [1, 2, 3, 4]
+    b_vals = [5, 6, 7, 8]
+    a_bytes = b"".join(v.to_bytes(4, "little", signed=True) for v in a_vals)
+    b_bytes = b"".join(v.to_bytes(4, "little", signed=True) for v in b_vals)
+
+    a_ptr = gpu.malloc(len(a_bytes))
+    b_ptr = gpu.malloc(len(b_bytes))
+    out_ptr = gpu.malloc(len(a_bytes))
+
+    gpu.memcpy_host_to_device(a_bytes, a_ptr)
+    gpu.memcpy_host_to_device(b_bytes, b_ptr)
+
+    vec_mul(a_ptr, b_ptr, out_ptr)
+    gpu.synchronize()
+
+    out = gpu.memcpy_device_to_host(out_ptr, len(a_bytes))
+    result = [int.from_bytes(out[i * 4:(i + 1) * 4], "little", signed=True) for i in range(4)]
+    expected = [a_vals[i] * b_vals[i] for i in range(4)]
+
+    print("Kernel result:", result)
+    print("Host result:", expected)
+    if result == expected:
+        print("Vector multiplication successful!")
+    else:
+        print("Mismatch detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def test_vector_mul_example(capsys):
+    mod = importlib.import_module("examples.vector_mul")
+    mod.main()
+    out = capsys.readouterr().out.lower()
+    assert "successful" in out
+
+
+def test_convolution_example(capsys):
+    mod = importlib.import_module("examples.convolution_2d")
+    mod.main()
+    out = capsys.readouterr().out.lower()
+    assert "successful" in out


### PR DESCRIPTION
## Summary
- add `examples` package with simple scripts
- demonstrate vector multiplication kernel execution
- demonstrate a 2D convolution using shared and constant memory
- document how to run the examples
- include tests verifying the examples work

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c098c7eb883319b2c529a7ff18de2