### PR TITLE
Add constant_memory attribute and tests

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -29,6 +29,7 @@ from .memory_hierarchy import (
 )
 
 const_memory = ConstantMemory
+constant_memory = ConstantMemory
 
 __all__ = [
     "VirtualGPU",
@@ -49,6 +50,7 @@ __all__ = [
     "GlobalMemorySpace",
     "ConstantMemory",
     "const_memory",
+    "constant_memory",
     "LocalMemory",
     "HostMemory",
     "TransferEvent",

--- a/tests/test_constant_memory.py
+++ b/tests/test_constant_memory.py
@@ -15,15 +15,18 @@ class DummySM:
 
 def test_constant_memory_default_size_and_set():
     gpu = VirtualGPU(0, 32)
-    assert gpu.const_memory.size == 64 * 1024
+    assert gpu.constant_memory.size == 64 * 1024
     gpu.set_constant(b"abc")
-    assert gpu.const_memory.read(0, 3) == b"abc"
+    assert gpu.constant_memory.read(0, 3) == b"abc"
+
+    # ``const_memory`` remains for backward compatibility
+    assert gpu.const_memory is gpu.constant_memory
 
 
 def test_set_constant_bounds():
     gpu = VirtualGPU(0, 16)
     with pytest.raises(ValueError):
-        gpu.set_constant(b"a" * (gpu.const_memory.size + 1))
+        gpu.set_constant(b"a" * (gpu.constant_memory.size + 1))
 
 
 def test_launch_kernel_exposes_const_mem():
@@ -36,7 +39,8 @@ def test_launch_kernel_exposes_const_mem():
     gpu.launch_kernel(dummy, (1, 1, 1), (1, 1, 1))
     tb = gpu.sms[0].block_queue.get()
     t = tb.threads[0]
-    assert t.const_mem is gpu.const_memory
+    assert t.const_mem is gpu.constant_memory
+    assert t.constant_mem is gpu.constant_memory
 
 
 def test_read_constant_wrapper():


### PR DESCRIPTION
## Summary
- expose `constant_memory` attribute inside `VirtualGPU`
- update `set_constant` and `read_constant` to use new attribute
- expose constant memory pointer for threads
- export `constant_memory` in `__all__`
- adapt constant memory tests to new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0b848b808331b3950b5281d3eb9f