### PR TITLE
Add result checks for example tests

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,19 +1,30 @@
 import os
 import sys
 import importlib
+import ast
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _parse_results(output: str):
+    kernel = host = None
+    for line in output.splitlines():
+        if line.startswith("Kernel result:"):
+            kernel = ast.literal_eval(line.split(":", 1)[1].strip())
+        if line.startswith("Host result:"):
+            host = ast.literal_eval(line.split(":", 1)[1].strip())
+    return kernel, host
 
 
 def test_vector_mul_example(capsys):
     mod = importlib.import_module("examples.vector_mul")
     mod.main()
-    out = capsys.readouterr().out.lower()
-    assert "successful" in out
+    kernel, host = _parse_results(capsys.readouterr().out)
+    assert kernel == host
 
 
 def test_convolution_example(capsys):
     mod = importlib.import_module("examples.convolution_2d")
     mod.main()
-    out = capsys.readouterr().out.lower()
-    assert "successful" in out
+    kernel, host = _parse_results(capsys.readouterr().out)
+    assert kernel == host


### PR DESCRIPTION
## Summary
- parse output from example scripts to compare kernel and host results
- check equality instead of simple success strings

## Testing
- `pytest -q tests/test_examples.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c0b7f242483318311db0ea0ddc6b9