### PR TITLE
Add DevicePointer index operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ def hello(threadIdx, blockIdx, blockDim, gridDim, msg):
 
 hello("Oi")
 
-ptr = gpu.malloc(4)
-gpu.memcpy_host_to_device(b"data", ptr)
-data = gpu.memcpy_device_to_host(ptr, 4)
-print(data)
+ptr = gpu.malloc(8)
+ptr[0] = b"abcd"
+ptr[1] = b"efgh"
+print(ptr[0], ptr[1])
 gpu.free(ptr)
 
 # Leitura de memoria constante

--- a/py_virtual_gpu/memory.py
+++ b/py_virtual_gpu/memory.py
@@ -38,14 +38,24 @@ class DevicePointer:
     # Memory access helpers
     # ------------------------------------------------------------------
     def __getitem__(self, index: int) -> bytes:
+        """Return the element at ``index`` from the current device's global memory."""
+
+        from .virtualgpu import VirtualGPU
+
         off = self.offset + index * self.element_size
-        return self.memory.read(off, self.element_size)
+        gpu = VirtualGPU.get_current()
+        return gpu.global_memory.read(off, self.element_size)
 
     def __setitem__(self, index: int, data: bytes) -> None:
+        """Store ``data`` into ``index`` on the current device's global memory."""
+
+        from .virtualgpu import VirtualGPU
+
         if len(data) != self.element_size:
             raise ValueError("data length must match element_size")
         off = self.offset + index * self.element_size
-        self.memory.write(off, data)
+        gpu = VirtualGPU.get_current()
+        gpu.global_memory.write(off, data)
 
     # ------------------------------------------------------------------
     # Representation helpers

--- a/tests/test_device_pointer_index.py
+++ b/tests/test_device_pointer_index.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU
+
+
+def test_device_pointer_index_read_write():
+    gpu = VirtualGPU(0, 32)
+    VirtualGPU.set_current(gpu)
+    ptr = gpu.malloc(8)
+
+    ptr[0] = b"abcd"
+    ptr[1] = b"efgh"
+
+    assert ptr[0] == b"abcd"
+    assert ptr[1] == b"efgh"
+    assert gpu.global_memory.read(ptr.offset, 4) == b"abcd"
+    assert gpu.global_memory.read(ptr.offset + 4, 4) == b"efgh"
+
+
+def test_device_pointer_setitem_size_mismatch():
+    gpu = VirtualGPU(0, 16)
+    VirtualGPU.set_current(gpu)
+    ptr = gpu.malloc(4)
+    with pytest.raises(ValueError):
+        ptr[0] = b"ab"


### PR DESCRIPTION
## Summary
- implement `__getitem__` and `__setitem__` for `DevicePointer`
- use current VirtualGPU global memory when indexing pointers
- add example of pointer indexing in README
- add new tests for index read/write on host side

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c106808dc8331a35eb19dec5edb72