### PR TITLE
Add FastAPI API scaffolding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: dev-api
+
+dev-api:
+python -m uvicorn py_virtual_gpu.api.main:app --reload --port 8000

--- a/README.md
+++ b/README.md
@@ -84,3 +84,15 @@ gpu.free(ptr)
 gpu.set_constant(b"abc")
 print(gpu.read_constant(0, 3))
 ```
+
+## API
+
+Para iniciar a API execute:
+
+```bash
+pip install -e .[api]
+make dev-api
+```
+
+A documentação Swagger estará disponível em http://localhost:8000/docs.
+

--- a/py_virtual_gpu/api/__init__.py
+++ b/py_virtual_gpu/api/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI application for py_virtual_gpu."""
+
+from .main import app
+
+__all__ = ["app"]

--- a/py_virtual_gpu/api/main.py
+++ b/py_virtual_gpu/api/main.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from ..virtualgpu import VirtualGPU
+
+app = FastAPI(title="Py Virtual GPU API")
+
+gpu = VirtualGPU(num_sms=1, global_mem_size=1024)
+
+
+@app.get("/status")
+def read_status() -> dict[str, int]:
+    """Return basic information about the simulated GPU."""
+
+    return {
+        "num_sms": len(gpu.sms),
+        "global_mem_size": gpu.global_memory.size,
+        "shared_mem_size": gpu.shared_mem_size,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "py_virtual_gpu"
+version = "0.1.0"
+description = "Python Virtual GPU simulator"
+authors = [{name="Diego Rodrigues"}]
+readme = "README.md"
+requires-python = ">=3.10"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["py_virtual_gpu*"]
+
+[project.optional-dependencies]
+api = ["fastapi", "uvicorn[standard]"]


### PR DESCRIPTION
## Summary
- configure editable install via `pyproject.toml`
- expose `/status` endpoint using FastAPI
- add Makefile convenience command to run the API
- document how to start the API server

## Testing
- `pip install -e .[api]`
- `uvicorn py_virtual_gpu.api.main:app --port 8000 --timeout-keep-alive 1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c15a801088331b38598734f313f24