### PR TITLE
Add httpx to API extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,5 @@ where = ["."]
 include = ["py_virtual_gpu*"]
 
 [project.optional-dependencies]
-api = ["fastapi", "uvicorn[standard]"]
+# Include httpx so FastAPI's TestClient works out of the box
+api = ["fastapi", "uvicorn[standard]", "httpx"]


### PR DESCRIPTION
## Summary
- include `httpx` in the `api` extra so `fastapi.testclient` works without manual installs

## Testing
- `pip install -e .[api]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c1ad80c6c8331bbf7cb42b11a6f55