### PR TITLE
Implement GPUManager service

### DIFF
--- a/py_virtual_gpu/api/main.py
+++ b/py_virtual_gpu/api/main.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
 from ..virtualgpu import VirtualGPU
+from ..services import GPUManager, get_gpu_manager
 
 app = FastAPI(title="Py Virtual GPU API")
 
-gpu = VirtualGPU(num_sms=1, global_mem_size=1024)
+
+@app.on_event("startup")
+def startup_event() -> None:
+    """Register a default GPU instance on application startup."""
+
+    manager = get_gpu_manager()
+    if not manager.list_gpus():
+        manager.add_gpu(VirtualGPU(num_sms=1, global_mem_size=1024))
 
 
 @app.get("/status")
-def read_status() -> dict[str, int]:
+def read_status(
+    manager: GPUManager = Depends(get_gpu_manager),
+) -> dict[str, int]:
     """Return basic information about the simulated GPU."""
 
+    gpu = manager.get_gpu(0)
     return {
         "num_sms": len(gpu.sms),
         "global_mem_size": gpu.global_memory.size,

--- a/py_virtual_gpu/services/__init__.py
+++ b/py_virtual_gpu/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for managing GPU instances."""
+
+from .gpu_manager import GPUManager, get_gpu_manager
+
+__all__ = ["GPUManager", "get_gpu_manager"]

--- a/py_virtual_gpu/services/gpu_manager.py
+++ b/py_virtual_gpu/services/gpu_manager.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import List
+
+from ..virtualgpu import VirtualGPU
+
+
+class GPUManager:
+    """Singleton manager for :class:`VirtualGPU` instances."""
+
+    _instance: "GPUManager" | None = None
+
+    def __new__(cls) -> "GPUManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._gpus: List[VirtualGPU] = []
+        return cls._instance
+
+    # simple init that does nothing to avoid reinitializing on repeated calls
+    def __init__(self) -> None:  # pragma: no cover - __new__ handles singleton init
+        pass
+
+    def add_gpu(self, gpu: VirtualGPU) -> int:
+        """Register ``gpu`` and return its id."""
+
+        self._gpus.append(gpu)
+        return len(self._gpus) - 1
+
+    def list_gpus(self) -> List[VirtualGPU]:
+        """Return a list of registered GPUs."""
+
+        return list(self._gpus)
+
+    def get_gpu(self, id: int) -> VirtualGPU:
+        """Return the GPU with ``id`` or raise ``IndexError`` if not found."""
+
+        if id < 0 or id >= len(self._gpus):
+            raise IndexError("Invalid GPU id")
+        return self._gpus[id]
+
+
+def get_gpu_manager() -> GPUManager:
+    """FastAPI dependency returning the singleton :class:`GPUManager`."""
+
+    return GPUManager()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,20 +8,20 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from py_virtual_gpu.api import app
 
-client = TestClient(app)
-
 
 def test_status_endpoint():
-    resp = client.get("/status")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["num_sms"] == 1
-    assert data["global_mem_size"] == 1024
-    assert data["shared_mem_size"] == 0
+    with TestClient(app) as client:
+        resp = client.get("/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["num_sms"] == 1
+        assert data["global_mem_size"] == 1024
+        assert data["shared_mem_size"] == 0
 
 
 def test_openapi_schema_includes_status():
-    resp = client.get("/openapi.json")
-    assert resp.status_code == 200
-    schema = resp.json()
-    assert "/status" in schema.get("paths", {})
+    with TestClient(app) as client:
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        assert "/status" in schema.get("paths", {})

--- a/tests/test_gpu_manager.py
+++ b/tests/test_gpu_manager.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+from py_virtual_gpu.services import GPUManager, get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+
+
+def test_startup_registers_gpu():
+    with TestClient(app):  # triggers startup event
+        manager = get_gpu_manager()
+        gpus = manager.list_gpus()
+        assert len(gpus) >= 1
+        assert isinstance(manager.get_gpu(0), VirtualGPU)
+
+
+def test_gpu_manager_add_and_get():
+    manager = GPUManager()
+    start = len(manager.list_gpus())
+    gpu = VirtualGPU(num_sms=2, global_mem_size=512)
+    idx = manager.add_gpu(gpu)
+    assert idx == start
+    assert manager.get_gpu(idx) is gpu
+    assert len(manager.list_gpus()) == start + 1
+
+
+def test_get_gpu_invalid_id():
+    manager = GPUManager()
+    with pytest.raises(IndexError):
+        manager.get_gpu(-1)
+    with pytest.raises(IndexError):
+        manager.get_gpu(999)


### PR DESCRIPTION
## Summary
- add `GPUManager` singleton service and dependency helper
- register default GPU on API startup and inject via `Depends`
- adjust API tests for startup dependency
- test the manager with 100% coverage

## Testing
- `pytest -q`
- `pytest --cov=py_virtual_gpu.services.gpu_manager tests/test_gpu_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685c1fac65ac8331b96edb3c32a330bf