### PR TITLE
Add GPU listing API endpoint

### DIFF
--- a/py_virtual_gpu/api/main.py
+++ b/py_virtual_gpu/api/main.py
@@ -4,8 +4,10 @@ from fastapi import Depends, FastAPI
 
 from ..virtualgpu import VirtualGPU
 from ..services import GPUManager, get_gpu_manager
+from .routers import gpus as gpus_router
 
 app = FastAPI(title="Py Virtual GPU API")
+app.include_router(gpus_router.router)
 
 
 @app.on_event("startup")

--- a/py_virtual_gpu/api/routers/__init__.py
+++ b/py_virtual_gpu/api/routers/__init__.py
@@ -1,0 +1,5 @@
+"""API routers for py_virtual_gpu."""
+
+from . import gpus
+
+__all__ = ["gpus"]

--- a/py_virtual_gpu/api/routers/gpus.py
+++ b/py_virtual_gpu/api/routers/gpus.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from ...services import GPUManager, get_gpu_manager
+from ..schemas import GPUSummary
+
+router = APIRouter()
+
+
+@router.get("/gpus", response_model=list[GPUSummary])
+def list_gpus(manager: GPUManager = Depends(get_gpu_manager)) -> list[GPUSummary]:
+    """Return a summary of all registered GPUs."""
+    summaries = []
+    for idx, gpu in enumerate(manager.list_gpus()):
+        summaries.append(
+            GPUSummary(
+                id=idx,
+                num_sms=len(gpu.sms),
+                global_mem_size=gpu.global_memory.size,
+                shared_mem_size=gpu.shared_mem_size,
+            )
+        )
+    return summaries

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GPUSummary(BaseModel):
+    """Basic information about a simulated GPU."""
+
+    id: int
+    num_sms: int
+    global_mem_size: int
+    shared_mem_size: int

--- a/tests/test_gpus_endpoint.py
+++ b/tests/test_gpus_endpoint.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+from py_virtual_gpu.services import GPUManager, get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+
+
+def test_gpus_endpoint_multi_gpu():
+    manager = get_gpu_manager()
+    manager._gpus.clear()
+    manager.add_gpu(VirtualGPU(num_sms=2, global_mem_size=256))
+    manager.add_gpu(VirtualGPU(num_sms=4, global_mem_size=512))
+
+    with TestClient(app) as client:
+        resp = client.get("/gpus")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 2
+        assert data[0]["id"] == 0
+        assert data[0]["num_sms"] == 2
+        assert data[0]["global_mem_size"] == 256
+        assert data[1]["id"] == 1
+        assert data[1]["num_sms"] == 4
+        assert data[1]["global_mem_size"] == 512


### PR DESCRIPTION
## Summary
- define `GPUSummary` schema for API responses
- add `/gpus` router and register it in FastAPI app
- test listing multiple virtual GPUs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c223937f88331bed00761a4e2a790