### PR TITLE
Implement GPU state endpoint

### DIFF
--- a/py_virtual_gpu/api/routers/gpus.py
+++ b/py_virtual_gpu/api/routers/gpus.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from ...services import GPUManager, get_gpu_manager
-from ..schemas import GPUSummary
+from ..schemas import GPUSummary, GPUState
 
 router = APIRouter()
 
@@ -22,3 +22,10 @@ def list_gpus(manager: GPUManager = Depends(get_gpu_manager)) -> list[GPUSummary
             )
         )
     return summaries
+
+
+@router.get("/gpus/{id}/state", response_model=GPUState)
+def gpu_state(id: int, manager: GPUManager = Depends(get_gpu_manager)) -> GPUState:
+    """Return a detailed snapshot for the GPU with ``id``."""
+
+    return manager.get_gpu_state(id)

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -10,3 +10,37 @@ class GPUSummary(BaseModel):
     num_sms: int
     global_mem_size: int
     shared_mem_size: int
+
+
+class TransferRecord(BaseModel):
+    """Serialized memory transfer event."""
+
+    direction: str
+    size: int
+    start_cycle: int
+    end_cycle: int
+
+
+class GlobalMemState(BaseModel):
+    """State of the GPU global memory."""
+
+    size: int
+    used: int
+
+
+class SMState(BaseModel):
+    """State information for a single SM."""
+
+    id: int
+    status: str
+    counters: dict[str, int]
+
+
+class GPUState(BaseModel):
+    """Detailed snapshot of a GPU."""
+
+    id: int
+    global_memory: GlobalMemState
+    transfer_log: list[TransferRecord]
+    sms: list[SMState]
+

--- a/py_virtual_gpu/services/gpu_manager.py
+++ b/py_virtual_gpu/services/gpu_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import List
+from dataclasses import asdict
 
 from ..virtualgpu import VirtualGPU
 
@@ -37,6 +38,28 @@ class GPUManager:
         if id < 0 or id >= len(self._gpus):
             raise IndexError("Invalid GPU id")
         return self._gpus[id]
+
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+    def get_gpu_state(self, id: int):
+        """Return a detailed snapshot of the GPU with ``id``."""
+
+        from ..api.schemas import GPUState, SMState, GlobalMemState, TransferRecord
+
+        gpu = self.get_gpu(id)
+
+        gm = gpu.global_memory
+        gm_state = GlobalMemState(size=gm.size, used=sum(gm.allocations.values()))
+
+        transfer_log = [TransferRecord(**asdict(ev)) for ev in gpu.get_transfer_log()]
+
+        sms = []
+        for sm in gpu.sms:
+            status = "idle" if sm.block_queue.empty() and sm.warp_queue.empty() else "busy"
+            sms.append(SMState(id=sm.id, status=status, counters=sm.counters.copy()))
+
+        return GPUState(id=id, global_memory=gm_state, transfer_log=transfer_log, sms=sms)
 
 
 def get_gpu_manager() -> GPUManager:

--- a/tests/test_gpu_state_endpoint.py
+++ b/tests/test_gpu_state_endpoint.py
@@ -1,0 +1,65 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+import queue
+
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+from py_virtual_gpu.warp import Warp
+
+
+def _setup_gpu(num_sms=1):
+    manager = get_gpu_manager()
+    manager._gpus.clear()
+    gpu = VirtualGPU(num_sms=num_sms, global_mem_size=64)
+    for sm in gpu.sms:
+        sm.block_queue = queue.Queue()
+    manager.add_gpu(gpu)
+    return gpu
+
+
+def test_state_endpoint_idle():
+    _setup_gpu(num_sms=2)
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/state")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["global_memory"]["used"] == 0
+        assert len(data["sms"]) == 2
+        for sm in data["sms"]:
+            assert sm["status"] == "idle"
+            assert sm["counters"]["warps_executed"] == 0
+
+
+@pytest.mark.parametrize("policy", ["sequential", "round_robin"])
+def test_state_endpoint_reports_warps(policy):
+    gpu = _setup_gpu()
+    gpu.sms[0].schedule_policy = policy
+
+    def dummy():
+        pass
+
+    mp = pytest.MonkeyPatch()
+
+    def _nop(self):
+        self.active_mask = [False] * len(self.active_mask)
+
+    mp.setattr(Warp, "execute", _nop)
+
+    gpu.launch_kernel(dummy, (1, 1, 1), (64, 1, 1))
+    gpu.synchronize()
+    mp.undo()
+
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/state")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sms"][0]["counters"]["warps_executed"] == 2
+
+


### PR DESCRIPTION
## Summary
- add new GPUState, SMState, GlobalMemState, and TransferRecord schemas
- expose `/gpus/{id}/state` API endpoint
- implement `GPUManager.get_gpu_state` helper
- include tests for the new endpoint with fake kernel execution

## Testing
- `pip install fastapi uvicorn[standard] httpx -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c25225bfc8331a19bf6d25e8a2068