### PR TITLE
Implement SM detail endpoint

### DIFF
--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -56,3 +56,36 @@ class GPUMetrics(BaseModel):
     memory_stats: dict[str, int]
     transfer_stats: dict[str, int]
 
+
+class BlockSummary(BaseModel):
+    """Minimal information about a block scheduled on an SM."""
+
+    block_idx: tuple[int, int, int]
+    status: str
+
+
+class WarpSummary(BaseModel):
+    """Basic state for a warp queued on an SM."""
+
+    id: int
+    active_threads: int
+
+
+class DivergenceRecord(BaseModel):
+    """Serialized record of a warp divergence event."""
+
+    warp_id: int
+    pc: int
+    mask_before: list[bool]
+    mask_after: list[bool]
+
+
+class SMDetailed(BaseModel):
+    """Detailed information for a single StreamingMultiprocessor."""
+
+    id: int
+    blocks: list[BlockSummary]
+    warps: list[WarpSummary]
+    divergence_log: list[DivergenceRecord]
+    counters: dict[str, int]
+

--- a/tests/test_sm_detail_endpoint.py
+++ b/tests/test_sm_detail_endpoint.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import queue
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+from py_virtual_gpu.warp import Warp
+from py_virtual_gpu.thread import Thread
+
+
+def _setup_gpu(num_sms=1):
+    manager = get_gpu_manager()
+    manager._gpus.clear()
+    gpu = VirtualGPU(num_sms=num_sms, global_mem_size=64)
+    for sm in gpu.sms:
+        sm.block_queue = queue.Queue()
+    manager.add_gpu(gpu)
+    return gpu
+
+
+def test_sm_detail_not_found():
+    _setup_gpu()
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/sm/99")
+        assert resp.status_code == 404
+
+
+def test_sm_detail_divergence_log_size():
+    gpu = _setup_gpu()
+    sm = gpu.sms[0]
+    sm.record_divergence(Warp(0, [Thread(), Thread()], sm), 0, [True, True], [True, False])
+    sm.record_divergence(Warp(0, [Thread(), Thread()], sm), 1, [True, False], [True, True])
+
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/sm/0")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["counters"]["warp_divergences"] == len(data["divergence_log"])


### PR DESCRIPTION
## Summary
- add BlockSummary, WarpSummary, DivergenceRecord and SMDetailed schemas
- expose new `get_sm_detail` in GPUManager
- add `/gpus/{id}/sm/{sm_id}` router
- test SM detail endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c283be16c83318cfe74e7ff586db2