### PR TITLE
Implement global events feed

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -1,6 +1,6 @@
 """Top-level package for the virtual GPU simulator."""
 
-from .virtualgpu import VirtualGPU
+from .virtualgpu import VirtualGPU, KernelLaunchEvent
 from .global_memory import GlobalMemory
 from .memory import DevicePointer
 from .streaming_multiprocessor import StreamingMultiprocessor, DivergenceEvent
@@ -54,6 +54,7 @@ __all__ = [
     "LocalMemory",
     "HostMemory",
     "TransferEvent",
+    "KernelLaunchEvent",
     "atomicAdd",
     "atomicSub",
     "atomicCAS",

--- a/py_virtual_gpu/api/main.py
+++ b/py_virtual_gpu/api/main.py
@@ -31,3 +31,14 @@ def read_status(
         "global_mem_size": gpu.global_memory.size,
         "shared_mem_size": gpu.shared_mem_size,
     }
+
+
+@app.get("/events")
+def get_events(
+    since_cycle: int | None = None,
+    limit: int = 100,
+    manager: GPUManager = Depends(get_gpu_manager),
+) -> list[dict]:
+    """Return a consolidated, time-ordered event feed."""
+
+    return manager.get_event_feed(since_cycle, limit)

--- a/tests/test_events_endpoint.py
+++ b/tests/test_events_endpoint.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import queue
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+from py_virtual_gpu.warp import Warp
+from py_virtual_gpu.thread import Thread
+
+
+def _setup_gpu():
+    manager = get_gpu_manager()
+    manager._gpus.clear()
+    gpu = VirtualGPU(num_sms=1, global_mem_size=64)
+    for sm in gpu.sms:
+        sm.block_queue = queue.Queue()
+    manager.add_gpu(gpu)
+    return gpu
+
+
+def test_events_endpoint_returns_all():
+    gpu = _setup_gpu()
+    ptr = gpu.malloc(8)
+    gpu.memcpy_host_to_device(b"a" * 8, ptr)
+    gpu.memcpy_device_to_host(ptr, 8)
+    sm = gpu.sms[0]
+    sm.record_divergence(Warp(0, [Thread(), Thread()], sm), 0, [True, True], [True, False])
+
+    def dummy():
+        pass
+
+    gpu.launch_kernel(dummy, (1, 1, 1), (1, 1, 1))
+
+    with TestClient(app) as client:
+        resp = client.get("/events")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 4
+        assert data == sorted(data, key=lambda e: e["start_cycle"])


### PR DESCRIPTION
## Summary
- add `KernelLaunchEvent` logging to `VirtualGPU`
- include cycle info when recording divergence events
- aggregate kernel, transfer and divergence logs via `GPUManager.get_event_feed`
- expose new `/events` endpoint in API
- test that `/events` returns all recorded events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c29cf58b08331a7fb546fb3c77b2d