### PR TITLE
Fix VirtualGPU memcpy DeviceToHost handling

### DIFF
--- a/py_virtual_gpu/virtualgpu.py
+++ b/py_virtual_gpu/virtualgpu.py
@@ -225,6 +225,13 @@ class VirtualGPU:
     ) -> None:
         """Copy data between host and device according to ``direction``."""
 
+        # GlobalMemory.memcpy expects the device offset as the first argument
+        # when performing a DeviceToHost transfer. In that case, the host
+        # destination is ignored, so we pass ``None`` for the second argument.
+        if direction == "DeviceToHost":
+            src_ptr = src.offset if isinstance(src, DevicePointer) else src
+            return self.global_memory.memcpy(src_ptr, None, size, direction)
+
         dest_ptr = dest.offset if isinstance(dest, DevicePointer) else dest
         src_ptr = src.offset if isinstance(src, DevicePointer) else src
         return self.global_memory.memcpy(dest_ptr, src_ptr, size, direction)

--- a/tests/test_virtualgpu_memory.py
+++ b/tests/test_virtualgpu_memory.py
@@ -85,3 +85,21 @@ def test_memcpy_validation_errors():
     with pytest.raises(ValueError):
         gpu.memcpy_host_to_device(b"abcd", ptr)
 
+
+def test_generic_memcpy_operations():
+    gpu = VirtualGPU(0, 32)
+    ptr = gpu.malloc(6)
+
+    # Host to Device
+    gpu.memcpy(ptr, b"abcdef", 6, "HostToDevice")
+    assert gpu.global_memory.read(ptr.offset, 6) == b"abcdef"
+
+    # Device to Host
+    out = gpu.memcpy(None, ptr, 6, "DeviceToHost")
+    assert out == b"abcdef"
+
+    # Device to Device
+    dest = gpu.malloc(6)
+    gpu.memcpy(dest, ptr, 6, "DeviceToDevice")
+    assert gpu.global_memory.read(dest.offset, 6) == b"abcdef"
+


### PR DESCRIPTION
## Summary
- adjust argument order for `VirtualGPU.memcpy` when copying DeviceToHost
- test VirtualGPU's generic `memcpy` for all transfer directions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c4875518083319aad99e57d3eb735