### PR TITLE
Add CONTRIBUTING and update README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contribuindo
+
+## Setup de desenvolvimento
+
+1. Crie um ambiente virtual opcionalmente e instale o pacote no modo editável com as dependências opcionais definidas em `[project.optional-dependencies]` do `pyproject.toml`:
+
+```bash
+pip install -e .[api]
+```
+
+2. Instale também os pacotes listados em `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Execute a suíte de testes na raiz do repositório:
+
+```bash
+pytest
+```
+
+

--- a/README.md
+++ b/README.md
@@ -96,3 +96,28 @@ make dev-api
 
 A documentação Swagger estará disponível em http://localhost:8000/docs.
 
+## Setup de desenvolvimento
+
+Antes de executar a suíte de testes, instale o pacote com as dependências opcionais definidas em `[project.optional-dependencies]` do `pyproject.toml`:
+
+```bash
+pip install -e .[api]
+```
+
+Em seguida instale os pacotes de desenvolvimento listados em `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Por fim, rode a suíte de testes:
+
+```bash
+pytest
+```
+
+## Contribuindo
+
+Consulte [CONTRIBUTING.md](CONTRIBUTING.md) para mais detalhes de como contribuir.
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+httpx
+pytest


### PR DESCRIPTION
## Summary
- document dev setup in new CONTRIBUTING.md
- add dev setup section in README with install notes
- add requirements.txt listing optional deps and pytest

## Testing
- `pip install -e .[api]`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c48913ce08331a58f0e7e6d3f441c