### PR TITLE
Ensure GPU detail view displays states

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { GPUState, SimulatorEvent, GpuSummary, BackendData } from './types';
-import { fetchBackendData } from './gpuSimulatorService';
+import { fetchBackendData, fetchGpuState } from './gpuSimulatorService';
 import { IconChip, IconMemory, IconActivity, IconInfo, IconChevronDown, IconChevronUp, Tooltip, MemoryUsageDisplay, SmCard, GpuOverviewCard, TransfersDisplay, EventLog, IconGpu, IconLink, StatDisplay } from './components';
 
 
@@ -16,7 +16,7 @@ interface DashboardLayoutProps {
   onSetView: (view: 'cluster' | 'detail') => void; // Changed from onToggleView
 }
 
-const DashboardLayout: React.FC<DashboardLayoutProps> = ({
+export const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   gpuSummaries, selectedGpu, events, onSelectGpu, isLoading, currentView, onSetView, allGpuStates
 }) => {
   const selectedGpuId = selectedGpu?.id;
@@ -61,25 +61,24 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
         )}
       </div>
 
-      {currentView === 'cluster' && allGpuStates.length > 0 && (
-        <GpuClusterView 
-          summaries={gpuSummaries} 
-          onSelectGpu={(id) => { 
-            onSelectGpu(id); 
-            onSetView('detail'); // Directly set view to detail
-          }} 
-          selectedGpuId={selectedGpuId} 
+      {currentView === 'cluster' && (
+        <GpuClusterView
+          summaries={gpuSummaries}
+          onSelectGpu={handleSelectGpu}
+          selectedGpuId={selectedGpuId}
         />
       )}
       
-      {currentView === 'detail' && selectedGpu && (
-        <GpuDetailView gpu={selectedGpu} />
-      )}
-      
-      {currentView === 'detail' && !selectedGpu && allGpuStates.length > 0 && !isLoading && (
-         <div className="text-center py-10 bg-gray-800 rounded-lg">
-           <p className="text-xl text-gray-400">Select a GPU to see details or switch to Cluster View.</p>
-         </div>
+      {currentView === 'detail' && (
+        selectedGpu ? (
+          <GpuDetailView gpu={selectedGpu} />
+        ) : (
+          !isLoading && (
+            <div className="text-center py-10 bg-gray-800 rounded-lg">
+              <p className="text-xl text-gray-400">Select a GPU to see details or switch to Cluster View.</p>
+            </div>
+          )
+        )
       )}
 
       {/* Render EventLog if there's data, or selectedGpu for detail view context */}
@@ -166,6 +165,7 @@ const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => (
 const App: React.FC = () => {
   const [backendData, setBackendData] = useState<BackendData | null>(null);
   const [selectedGpuId, setSelectedGpuId] = useState<string | null>(null);
+  const [selectedGpuState, setSelectedGpuState] = useState<GPUState | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [currentView, setCurrentView] = useState<'cluster' | 'detail'>('cluster');
@@ -204,6 +204,16 @@ const App: React.FC = () => {
     const intervalId = setInterval(loadData, 3000); 
     return () => clearInterval(intervalId);
   }, [loadData]);
+  const handleSelectGpu = async (id: string) => {
+    setSelectedGpuId(id);
+    try {
+      const state = await fetchGpuState(id);
+      setSelectedGpuState(state);
+    } catch (err) {
+      console.error('Failed to fetch GPU state', err);
+    }
+    handleSetView('detail');
+  };
 
   const handleSetView = (newView: 'cluster' | 'detail') => {
     if (newView === 'detail') {
@@ -219,7 +229,7 @@ const App: React.FC = () => {
     setCurrentView(newView);
   };
   
-  const selectedGpu = backendData?.gpuStates.find(gpu => gpu.id === selectedGpuId);
+  const selectedGpu = selectedGpuState ?? backendData?.gpuStates.find(gpu => gpu.id === selectedGpuId);
 
   useEffect(() => {
     if (backendData) {
@@ -283,7 +293,7 @@ const App: React.FC = () => {
           selectedGpu={selectedGpu}
           allGpuStates={backendData.gpuStates}
           events={backendData.events}
-          onSelectGpu={setSelectedGpuId}
+          onSelectGpu={handleSelectGpu}
           isLoading={isLoading && !!backendData} 
           currentView={currentView}
           onSetView={handleSetView} // Changed from onToggleView

--- a/app/src/__tests__/DashboardLayout.test.tsx
+++ b/app/src/__tests__/DashboardLayout.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { DashboardLayout } from '../App';
+import { GPUState, GpuSummary } from '../types/types';
+
+const gpu: GPUState = {
+  id: '0',
+  name: 'GPU 0',
+  config: { num_sms: 1, global_mem_size: 1024, shared_mem_per_sm_kb: 0, registers_per_sm_total: 0 },
+  global_memory: { used: 0, total: 1024 },
+  transfers: { H2D: 0, D2H: 0, bytes_transferred: 0 },
+  sms: [],
+  overall_load: 0,
+};
+
+const summary: GpuSummary = {
+  id: '0',
+  name: 'GPU 0',
+  globalMemoryUsed: 0,
+  globalMemoryTotal: 1024,
+  activeSMs: 0,
+  totalSMs: 1,
+  overallLoad: 0,
+  status: 'online'
+};
+
+describe('DashboardLayout view switching', () => {
+  it('shows cluster view when currentView is cluster', () => {
+    render(
+      <DashboardLayout
+        gpuSummaries={[summary]}
+        selectedGpu={gpu}
+        allGpuStates={[gpu]}
+        events={[]}
+        onSelectGpu={() => {}}
+        isLoading={false}
+        currentView="cluster"
+        onSetView={() => {}}
+      />
+    );
+    expect(screen.getByText('GPU Cluster Overview')).toBeInTheDocument();
+  });
+
+  it('shows detail view when currentView is detail', () => {
+    render(
+      <DashboardLayout
+        gpuSummaries={[summary]}
+        selectedGpu={gpu}
+        allGpuStates={[gpu]}
+        events={[]}
+        onSelectGpu={() => {}}
+        isLoading={false}
+        currentView="detail"
+        onSetView={() => {}}
+      />
+    );
+    expect(screen.getByText(/GPU 0 \(0\) - Details/)).toBeInTheDocument();
+  });
+});
+

--- a/app/src/__tests__/GpuDetailView.test.tsx
+++ b/app/src/__tests__/GpuDetailView.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { GpuDetailView } from '../App';
+import { GPUState } from '../types/types';
+
+describe('GpuDetailView', () => {
+  it('shows memory usage and sm cards', () => {
+    const gpu: GPUState = {
+      id: '0',
+      name: 'GPU 0',
+      config: {
+        num_sms: 1,
+        global_mem_size: 1024,
+        shared_mem_per_sm_kb: 0,
+        registers_per_sm_total: 0,
+      },
+      global_memory: { used: 512, total: 1024 },
+      transfers: { H2D: 1, D2H: 0, bytes_transferred: 512 },
+      sms: [
+        {
+          id: 0,
+          blocks_active: 1,
+          blocks_pending: 0,
+          warps_executed: 10,
+          warp_divergences: 0,
+          non_coalesced_accesses: 0,
+          shared_mem_usage_kb: 0,
+          shared_mem_total_kb: 0,
+          registers_used: undefined,
+          registers_total: undefined,
+          bank_conflicts: 0,
+          active_block_idx: undefined,
+          status: 'running',
+          load_percentage: 80,
+          active_warps: undefined,
+        },
+      ],
+      overall_load: 50,
+      temperature: 70,
+      power_draw_watts: 100,
+    };
+
+    render(<GpuDetailView gpu={gpu} />);
+    expect(screen.getByText('Global Memory')).toBeInTheDocument();
+    expect(screen.getByText('SM 0')).toBeInTheDocument();
+    expect(screen.getByText('50%')).toBeInTheDocument();
+  });
+});
+

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -36,13 +36,27 @@ class SMState(BaseModel):
     counters: dict[str, int]
 
 
+class GPUConfig(BaseModel):
+    """Configuration details for a GPU."""
+
+    num_sms: int
+    global_mem_size: int
+    shared_mem_size: int
+    registers_per_sm_total: int | None = None
+
+
 class GPUState(BaseModel):
     """Detailed snapshot of a GPU."""
 
     id: int
+    name: str
+    config: GPUConfig
     global_memory: GlobalMemState
     transfer_log: list[TransferRecord]
     sms: list[SMState]
+    overall_load: int
+    temperature: int | None = None
+    power_draw_watts: int | None = None
 
 
 class GPUMetrics(BaseModel):

--- a/tests/test_gpu_state_endpoint.py
+++ b/tests/test_gpu_state_endpoint.py
@@ -63,3 +63,15 @@ def test_state_endpoint_reports_warps(policy):
         assert data["sms"][0]["counters"]["warps_executed"] == 2
 
 
+def test_state_endpoint_includes_config_and_load():
+    _setup_gpu(num_sms=1)
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/state")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "GPU 0"
+        assert data["config"]["num_sms"] == 1
+        assert data["config"]["global_mem_size"] == 64
+        assert "overall_load" in data
+
+


### PR DESCRIPTION
## Summary
- extend `GPUState` with config and load metrics for detail views
- provide `GPUConfig` and update `GPUManager.get_gpu_state`
- test GPU state endpoint for the new fields

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `npx vitest run --silent` *(fails to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685c67966a808331901ff07aba98d259