### PR TITLE
Add background API server helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,22 @@ pip install -e .[api]
 make dev-api
 ```
 
+
 A documentação Swagger estará disponível em http://localhost:8000/docs.
+
+## Using with Jupyter/REPL
+
+To expose the API while working interactively start it in a background thread:
+
+```python
+from py_virtual_gpu.api.server import start_background_api
+
+thread, stop = start_background_api(port=8001)
+# ... interact with the API ...
+stop()
+```
+
+This is helpful when running notebooks or experimenting in the Python REPL.
 
 ## Setup de desenvolvimento
 

--- a/py_virtual_gpu/api/__init__.py
+++ b/py_virtual_gpu/api/__init__.py
@@ -1,5 +1,6 @@
 """FastAPI application for py_virtual_gpu."""
 
 from .main import app
+from .server import start_background_api
 
-__all__ = ["app"]
+__all__ = ["app", "start_background_api"]

--- a/py_virtual_gpu/api/server.py
+++ b/py_virtual_gpu/api/server.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import threading
+from typing import Callable, Tuple
+
+import uvicorn
+
+
+def start_background_api(host: str = "127.0.0.1", port: int = 8000) -> Tuple[threading.Thread, Callable[[], None]]:
+    """Start the FastAPI app in a background thread.
+
+    Parameters
+    ----------
+    host: str
+        Interface to bind the server to.
+    port: int
+        Port number for the server.
+
+    Returns
+    -------
+    tuple
+        ``(thread, stop_fn)`` where ``thread`` is the running server thread and
+        ``stop_fn`` stops the server and joins the thread.
+    """
+
+    config = uvicorn.Config("py_virtual_gpu.api.main:app", host=host, port=port, log_level="info")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    def stop() -> None:
+        server.should_exit = True
+        thread.join()
+
+    return thread, stop

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import time
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api.server import start_background_api
+
+
+def test_start_background_api():
+    thread, stop = start_background_api(port=8001)
+    try:
+        for _ in range(50):
+            try:
+                resp = httpx.get("http://127.0.0.1:8001/status", timeout=1.0)
+                if resp.status_code == 200:
+                    break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            pytest.fail("API server did not start")
+        assert thread.is_alive()
+    finally:
+        stop()
+        assert not thread.is_alive()


### PR DESCRIPTION
## Summary
- provide a `start_background_api` helper to run the FastAPI server in a thread
- expose the helper from `py_virtual_gpu.api`
- document usage for interactive sessions
- test the helper

## Testing
- `pip install -e .[api]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8714463c833188ddb351ace94288