### PR TITLE
Set API default GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ make dev-api
 
 
 A documentação Swagger estará disponível em http://localhost:8000/docs.
+Por padrão a aplicação inicializa duas GPUs com quatro SMs cada.
 
 ## Using with Jupyter/REPL
 

--- a/py_virtual_gpu/api/main.py
+++ b/py_virtual_gpu/api/main.py
@@ -16,7 +16,8 @@ async def lifespan(app: FastAPI):
 
     manager = get_gpu_manager()
     if not manager.list_gpus():
-        manager.add_gpu(VirtualGPU(num_sms=1, global_mem_size=1024))
+        for _ in range(2):
+            manager.add_gpu(VirtualGPU(num_sms=4, global_mem_size=1024))
     yield
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ def test_status_endpoint():
         resp = client.get("/status")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["num_sms"] == 1
+        assert data["num_sms"] == 4
         assert data["global_mem_size"] == 1024
         assert data["shared_mem_size"] == 0
 

--- a/tests/test_gpu_manager.py
+++ b/tests/test_gpu_manager.py
@@ -11,11 +11,12 @@ from py_virtual_gpu.virtualgpu import VirtualGPU
 
 
 def test_startup_registers_gpu():
+    manager = get_gpu_manager()
+    manager._gpus.clear()
     with TestClient(app):  # triggers startup event
-        manager = get_gpu_manager()
         gpus = manager.list_gpus()
-        assert len(gpus) >= 1
-        assert isinstance(manager.get_gpu(0), VirtualGPU)
+        assert len(gpus) == 2
+        assert all(len(g.sms) == 4 for g in gpus)
 
 
 def test_gpu_manager_add_and_get():


### PR DESCRIPTION
## Summary
- default to 2 GPUs with 4 SMs each when the API starts
- mention default setup in README
- adjust status endpoint test for new defaults
- ensure startup test checks the new configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6740b5908331ac4d335cff148242