### PR TITLE
Add SM detail view

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -161,7 +161,7 @@ export const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => (
       {gpu.sms.length === 0 && <p className="text-gray-400 bg-gray-800 p-4 rounded-lg">No SMs configured or active for this GPU.</p>}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
         {gpu.sms.map(sm => (
-          <SmCard key={sm.id} sm={sm} />
+          <SmCard key={sm.id} sm={sm} gpuId={gpu.id} />
         ))}
       </div>
     </div>

--- a/app/src/__tests__/SmDetailView.test.tsx
+++ b/app/src/__tests__/SmDetailView.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { SmDetailView } from '../components/SmDetailView';
+import { SMDetailed } from '../types/types';
+
+describe('SmDetailView', () => {
+  it('renders block and warp info', () => {
+    const detail: SMDetailed = {
+      id: 0,
+      blocks: [{ block_idx: [0, 0, 0], status: 'pending' }],
+      warps: [{ id: 1, active_threads: 32 }],
+      divergence_log: [],
+      counters: {},
+    };
+    render(<SmDetailView sm={detail} />);
+    expect(screen.getByText(/Block \[0, 0, 0\] - pending/)).toBeInTheDocument();
+    expect(screen.getByText(/Warp 1: 32 threads active/)).toBeInTheDocument();
+  });
+});

--- a/app/src/components/SmDetailView.tsx
+++ b/app/src/components/SmDetailView.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { SMDetailed } from '../types/types';
+
+export const SmDetailView: React.FC<{ sm: SMDetailed }> = ({ sm }) => (
+  <div className="mt-2 text-sm">
+    <div className="mb-2">
+      <h5 className="font-semibold text-sky-300">Blocks</h5>
+      {sm.blocks.length === 0 ? (
+        <p className="text-gray-400">No blocks scheduled.</p>
+      ) : (
+        <ul className="list-disc list-inside">
+          {sm.blocks.map((b) => (
+            <li key={b.block_idx.join(',')}>
+              Block [{b.block_idx.join(', ')}] - {b.status}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+    <div>
+      <h5 className="font-semibold text-sky-300">Warps</h5>
+      {sm.warps.length === 0 ? (
+        <p className="text-gray-400">No warps queued.</p>
+      ) : (
+        <ul className="list-disc list-inside">
+          {sm.warps.map((w) => (
+            <li key={w.id}>Warp {w.id}: {w.active_threads} threads active</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  </div>
+);

--- a/app/src/components/components.tsx
+++ b/app/src/components/components.tsx
@@ -1,5 +1,15 @@
 import React, { useState } from 'react';
-import { GPUState, SimulatorEvent, GpuSummary, StreamingMultiprocessorState, GlobalMemoryState, TransfersState } from '../types/types';
+import {
+  GPUState,
+  SimulatorEvent,
+  GpuSummary,
+  StreamingMultiprocessorState,
+  GlobalMemoryState,
+  TransfersState,
+  SMDetailed,
+} from '../types/types';
+import { fetchSmDetail } from '../services/gpuSimulatorService';
+import { SmDetailView } from './SmDetailView';
 
 // --- Icons ---
 export const IconChip: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
@@ -142,8 +152,8 @@ export const MemoryUsageDisplay: React.FC<MemoryUsageDisplayProps> = ({ used, to
 };
 
 // --- SmCard ---
-interface SmCardProps { sm: StreamingMultiprocessorState; }
-export const SmCard: React.FC<SmCardProps> = ({ sm }) => {
+interface SmCardProps { sm: StreamingMultiprocessorState; gpuId: string; }
+export const SmCard: React.FC<SmCardProps> = ({ sm, gpuId }) => {
   const statusColors: Record<StreamingMultiprocessorState['status'], string> = {
     running: 'bg-green-500',
     idle: 'bg-gray-500',
@@ -151,6 +161,24 @@ export const SmCard: React.FC<SmCardProps> = ({ sm }) => {
     error: 'bg-red-500',
   };
   const loadPercentage = sm.load_percentage || 0;
+  const [detail, setDetail] = useState<SMDetailed | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const toggleDetail = async () => {
+    if (detail) {
+      setDetail(null);
+      return;
+    }
+    setLoading(true);
+    try {
+      const d = await fetchSmDetail(gpuId, String(sm.id));
+      setDetail(d);
+    } catch (err) {
+      console.error('Failed to fetch SM detail', err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div className="bg-gray-800 p-4 rounded-lg shadow-lg hover:shadow-sky-500/30 transition-shadow duration-300">
@@ -183,6 +211,15 @@ export const SmCard: React.FC<SmCardProps> = ({ sm }) => {
         )}
         {sm.active_block_idx && <StatDisplay label="Active Block" value={sm.active_block_idx} className="col-span-2"/>}
       </div>
+
+      <button
+        onClick={toggleDetail}
+        className="mt-3 px-3 py-1 bg-sky-600 hover:bg-sky-500 rounded text-xs"
+      >
+        {detail ? 'Hide Details' : 'View Details'}
+      </button>
+      {loading && <p className="text-xs text-gray-400 mt-1">Loading...</p>}
+      {detail && <SmDetailView sm={detail} />}
     </div>
   );
 };

--- a/app/src/services/gpuSimulatorService.ts
+++ b/app/src/services/gpuSimulatorService.ts
@@ -1,4 +1,4 @@
-import { GPUState, SimulatorEvent, GpuSummary, BackendData, StreamingMultiprocessorState, GPUConfig, TransfersState } from '../types/types';
+import { GPUState, SimulatorEvent, GpuSummary, BackendData, StreamingMultiprocessorState, GPUConfig, TransfersState, SMDetailed } from '../types/types';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE_URL || 'http://localhost:8000';
 
@@ -68,6 +68,20 @@ export const fetchGpuState = async (id: string): Promise<GPUState> => {
             (sms.filter((s) => s.status !== 'idle').length / sms.length) * 100,
           )
         : 0,
+  };
+};
+
+export const fetchSmDetail = async (
+  gpuId: string,
+  smId: string,
+): Promise<SMDetailed> => {
+  const detail = await fetchJSON<any>(`${API_BASE}/gpus/${gpuId}/sm/${smId}`);
+  return {
+    id: detail.id,
+    blocks: detail.blocks ?? [],
+    warps: detail.warps ?? [],
+    divergence_log: detail.divergence_log ?? [],
+    counters: detail.counters ?? {},
   };
 };
 

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -38,6 +38,31 @@ export interface StreamingMultiprocessorState {
   active_warps?: { id: number; active_threads: number; total_threads: number; pc?: number; status?: string }[];
 }
 
+export interface BlockSummary {
+  block_idx: [number, number, number];
+  status: string;
+}
+
+export interface WarpSummary {
+  id: number;
+  active_threads: number;
+}
+
+export interface DivergenceRecord {
+  warp_id: number;
+  pc: number;
+  mask_before: boolean[];
+  mask_after: boolean[];
+}
+
+export interface SMDetailed {
+  id: number;
+  blocks: BlockSummary[];
+  warps: WarpSummary[];
+  divergence_log: DivergenceRecord[];
+  counters: Record<string, number>;
+}
+
 export interface GPUState {
   id: string; 
   name: string; // e.g., "Simulated GPU Alpha"


### PR DESCRIPTION
## Summary
- support fetching SM detail via new API call
- extend types with `SMDetailed`
- render block/warp info with new `SmDetailView`
- show SM details from each SmCard
- test SmDetailView rendering

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d788346b483319a3b912ea0149d13