### PR TITLE
Improve examples with API/UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,39 @@ make dev-api
 A documentação Swagger estará disponível em http://localhost:8000/docs.
 Por padrão a aplicação inicializa duas GPUs com quatro SMs cada.
 
+## Running the Examples
+
+Example programs are located in [`examples/`](examples). They can be executed
+directly and optionally started with the API so that the dashboard UI reflects
+their progress.
+
+```bash
+# plain execution
+python examples/vector_mul.py
+
+# start with API support to visualize in the UI
+python examples/vector_mul.py --api
+```
+
+When ``--api`` is used the script launches the FastAPI server in the background
+and registers the created GPU with the global manager. You can then run the UI
+from the `app` directory to inspect the execution:
+
+```bash
+cd app && npm install && npm run dev
+```
+
+The dashboard makes periodic requests to `/gpus` to list available devices,
+`/gpus/<id>/state` for detailed metrics and `/events` for the event log. If you
+want to confirm the API is responding during an example run you can query these
+endpoints manually using `curl`:
+
+```bash
+curl http://localhost:8000/gpus
+curl http://localhost:8000/gpus/0/state
+curl http://localhost:8000/events
+```
+
 ## Using with Jupyter/REPL
 
 To expose the API while working interactively start it in a background thread:

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,31 @@ python examples/convolution_2d.py
 
 Each program allocates memory on the virtual device, launches a kernel and prints
 whether the result computed on the device matches the host computation.
+
+### Visualizing via API and UI
+
+Both examples accept the ``--api`` flag to start the FastAPI server while they
+run. When the server is active you can launch the dashboard UI from the
+``app`` directory:
+
+```bash
+cd app && npm install && npm run dev
+```
+
+Then run an example with API support enabled:
+
+```bash
+python examples/vector_mul.py --api
+```
+
+Open ``http://localhost:5173`` to inspect the execution step by step through the
+UI. When the script finishes the API server shuts down automatically.
+
+If you want to double check the data the UI is receiving you can hit the API
+directly while an example is running:
+
+```bash
+curl http://localhost:8000/gpus
+curl http://localhost:8000/gpus/0/state
+curl http://localhost:8000/events
+```

--- a/py_virtual_gpu/api/server.py
+++ b/py_virtual_gpu/api/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import threading
+import time
 from typing import Callable, Tuple
 
 import uvicorn
@@ -41,6 +42,9 @@ def start_background_api(host: str = "127.0.0.1", port: int = 8000) -> Tuple[thr
 
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
+
+    while not getattr(server, "started", True):
+        time.sleep(0.05)
 
     def stop() -> None:
         server.should_exit = True


### PR DESCRIPTION
## Summary
- register example GPUs with the manager
- optionally start the FastAPI server when running examples
- document how to visualize the examples in the dashboard UI
- add docs describing the endpoints the UI queries
- ensure API server thread waits for startup before returning

## Testing
- `pytest -q`
- `python examples/vector_mul.py --api`
- `python examples/convolution_2d.py --api`


------
https://chatgpt.com/codex/tasks/task_e_685d7d39afc08331ade2215ba052c127