### PR TITLE
Add memory viewer utilities

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,8 +1,9 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { GPUState, SimulatorEvent, GpuSummary, BackendData } from './types/types';
-import { fetchBackendData, fetchGpuState } from './services/gpuSimulatorService';
+import { GPUState, SimulatorEvent, GpuSummary, BackendData, MemorySlice } from './types/types';
+import { fetchBackendData, fetchGpuState, fetchGlobalMemorySlice, fetchConstantMemorySlice } from './services/gpuSimulatorService';
 import { IconChip, IconMemory, IconActivity, IconInfo, IconChevronDown, IconChevronUp, Tooltip, MemoryUsageDisplay, SmCard, GpuOverviewCard, TransfersDisplay, EventLog, IconGpu, IconLink, StatDisplay } from './components/components';
+import { MemoryViewer } from './components/MemoryViewer';
 
 
 interface DashboardLayoutProps {
@@ -134,39 +135,97 @@ const GpuClusterView: React.FC<{summaries: GpuSummary[], onSelectGpu: (id: strin
 );
 
 
-export const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => (
-  <div className="space-y-6">
-    <div className="bg-gray-800 p-6 rounded-lg shadow-xl">
-        <div className="flex flex-col md:flex-row justify-between md:items-center mb-6">
-            <h2 className="text-3xl font-bold text-sky-400 flex items-center">
-                <IconGpu className="w-8 h-8 mr-3 text-sky-500" /> {gpu.name} ({gpu.id}) - Details
-            </h2>
-            <div className="flex space-x-4 mt-3 md:mt-0">
-                <StatDisplay label="Overall Load" value={`${gpu.overall_load}%`} />
-                {gpu.temperature !== undefined && <StatDisplay label="Temp" value={`${gpu.temperature}°C`} />}
-                {gpu.power_draw_watts !== undefined && <StatDisplay label="Power" value={`${gpu.power_draw_watts}W`} />}
-            </div>
-        </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
-            <MemoryUsageDisplay used={gpu.global_memory.used} total={gpu.global_memory.total} label="Global Memory" />
-            <TransfersDisplay transfers={gpu.transfers}/>
-        </div>
-    </div>
+export const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => {
+  const [offset, setOffset] = useState(0);
+  const [size, setSize] = useState(64);
+  const [memType, setMemType] = useState<'global' | 'constant'>('global');
+  const [slice, setSlice] = useState<MemorySlice | null>(null);
+  const [loading, setLoading] = useState(false);
 
-    <div>
-      <h3 className="text-2xl font-semibold text-sky-400 mb-4 ml-1 flex items-center">
-        <IconChip className="w-7 h-7 mr-2 text-sky-500" /> Streaming Multiprocessors ({gpu.config.num_sms})
-      </h3>
-      {gpu.sms.length === 0 && <p className="text-gray-400 bg-gray-800 p-4 rounded-lg">No SMs configured or active for this GPU.</p>}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-        {gpu.sms.map(sm => (
-          <SmCard key={sm.id} sm={sm} gpuId={gpu.id} />
-        ))}
+  const fetchSlice = async () => {
+    setLoading(true);
+    try {
+      const s =
+        memType === 'global'
+          ? await fetchGlobalMemorySlice(gpu.id, offset, size)
+          : await fetchConstantMemorySlice(gpu.id, offset, size);
+      setSlice(s);
+    } catch (err) {
+      console.error('Failed to fetch memory slice', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-gray-800 p-6 rounded-lg shadow-xl">
+          <div className="flex flex-col md:flex-row justify-between md:items-center mb-6">
+              <h2 className="text-3xl font-bold text-sky-400 flex items-center">
+                  <IconGpu className="w-8 h-8 mr-3 text-sky-500" /> {gpu.name} ({gpu.id}) - Details
+              </h2>
+              <div className="flex space-x-4 mt-3 md:mt-0">
+                  <StatDisplay label="Overall Load" value={`${gpu.overall_load}%`} />
+                  {gpu.temperature !== undefined && <StatDisplay label="Temp" value={`${gpu.temperature}°C`} />}
+                  {gpu.power_draw_watts !== undefined && <StatDisplay label="Power" value={`${gpu.power_draw_watts}W`} />}
+              </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+              <MemoryUsageDisplay used={gpu.global_memory.used} total={gpu.global_memory.total} label="Global Memory" />
+              <TransfersDisplay transfers={gpu.transfers}/>
+          </div>
+
+          <div className="mt-4">
+            <h3 className="text-lg font-semibold text-sky-400 mb-2 flex items-center">
+              <IconMemory className="w-5 h-5 mr-2" /> Memory Inspector
+            </h3>
+            <div className="flex items-center space-x-2 mb-2">
+              <select
+                value={memType}
+                onChange={(e) => setMemType(e.target.value as 'global' | 'constant')}
+                className="bg-gray-700 p-1 rounded text-sm"
+              >
+                <option value="global">Global</option>
+                <option value="constant">Constant</option>
+              </select>
+              <input
+                type="number"
+                value={offset}
+                onChange={(e) => setOffset(Number(e.target.value))}
+                className="bg-gray-700 p-1 rounded w-24 text-sm"
+                placeholder="Offset"
+              />
+              <input
+                type="number"
+                value={size}
+                onChange={(e) => setSize(Number(e.target.value))}
+                className="bg-gray-700 p-1 rounded w-20 text-sm"
+                placeholder="Size"
+              />
+              <button onClick={fetchSlice} className="px-2 py-1 bg-sky-600 rounded text-xs">
+                Fetch
+              </button>
+            </div>
+            {loading && <p className="text-xs text-gray-400">Loading...</p>}
+            {slice && <MemoryViewer slice={slice} />}
+          </div>
+      </div>
+
+      <div>
+        <h3 className="text-2xl font-semibold text-sky-400 mb-4 ml-1 flex items-center">
+          <IconChip className="w-7 h-7 mr-2 text-sky-500" /> Streaming Multiprocessors ({gpu.config.num_sms})
+        </h3>
+        {gpu.sms.length === 0 && <p className="text-gray-400 bg-gray-800 p-4 rounded-lg">No SMs configured or active for this GPU.</p>}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {gpu.sms.map(sm => (
+            <SmCard key={sm.id} sm={sm} gpuId={gpu.id} />
+          ))}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 
 const App: React.FC = () => {

--- a/app/src/__tests__/MemoryViewer.test.tsx
+++ b/app/src/__tests__/MemoryViewer.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryViewer } from '../components/MemoryViewer';
+import { MemorySlice } from '../types/types';
+
+describe('MemoryViewer', () => {
+  it('renders hex and ascii view', () => {
+    const slice: MemorySlice = { offset: 0, size: 4, data: Buffer.from('test').toString('hex') };
+    render(<MemoryViewer slice={slice} />);
+    expect(screen.getByText('00000000')).toBeInTheDocument();
+    expect(screen.getAllByText('74').length).toBeGreaterThan(0);
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/MemoryViewer.tsx
+++ b/app/src/components/MemoryViewer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { MemorySlice } from '../types/types';
+
+export const MemoryViewer: React.FC<{ slice: MemorySlice }> = ({ slice }) => {
+  const bytes: number[] = [];
+  for (let i = 0; i < slice.data.length; i += 2) {
+    bytes.push(parseInt(slice.data.substr(i, 2), 16));
+  }
+  const rowSize = 16;
+  const rows: number[][] = [];
+  for (let i = 0; i < bytes.length; i += rowSize) {
+    rows.push(bytes.slice(i, i + rowSize));
+  }
+
+  const toAscii = (b: number) => (b >= 32 && b <= 126 ? String.fromCharCode(b) : '.');
+
+  return (
+    <div className="overflow-auto">
+      <table className="font-mono text-xs border-collapse">
+        <tbody>
+          {rows.map((row, idx) => (
+            <tr key={idx}>
+              <td className="pr-2 text-gray-400">
+                {(slice.offset + idx * rowSize).toString(16).padStart(8, '0')}
+              </td>
+              {row.map((b, i) => (
+                <td key={i} className="px-1">
+                  {b.toString(16).padStart(2, '0')}
+                </td>
+              ))}
+              <td className="pl-4 text-gray-500">{row.map(toAscii).join('')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/app/src/services/gpuSimulatorService.ts
+++ b/app/src/services/gpuSimulatorService.ts
@@ -1,4 +1,14 @@
-import { GPUState, SimulatorEvent, GpuSummary, BackendData, StreamingMultiprocessorState, GPUConfig, TransfersState, SMDetailed } from '../types/types';
+import {
+  GPUState,
+  SimulatorEvent,
+  GpuSummary,
+  BackendData,
+  StreamingMultiprocessorState,
+  GPUConfig,
+  TransfersState,
+  SMDetailed,
+  MemorySlice,
+} from '../types/types';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE_URL || 'http://localhost:8000';
 
@@ -108,5 +118,25 @@ export const fetchBackendData = async (): Promise<BackendData> => {
   const events = await fetchJSON<SimulatorEvent[]>(`${API_BASE}/events`);
 
   return { gpuSummaries, gpuStates, events };
+};
+
+export const fetchGlobalMemorySlice = async (
+  gpuId: string,
+  offset: number,
+  size: number,
+): Promise<MemorySlice> => {
+  return fetchJSON<MemorySlice>(
+    `${API_BASE}/gpus/${gpuId}/global_mem?offset=${offset}&size=${size}`,
+  );
+};
+
+export const fetchConstantMemorySlice = async (
+  gpuId: string,
+  offset: number,
+  size: number,
+): Promise<MemorySlice> => {
+  return fetchJSON<MemorySlice>(
+    `${API_BASE}/gpus/${gpuId}/constant_mem?offset=${offset}&size=${size}`,
+  );
 };
 

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -55,6 +55,12 @@ export interface DivergenceRecord {
   mask_after: boolean[];
 }
 
+export interface MemorySlice {
+  offset: number;
+  size: number;
+  data: string; // hex-encoded
+}
+
 export interface SMDetailed {
   id: number;
   blocks: BlockSummary[];

--- a/app/types.ts
+++ b/app/types.ts
@@ -20,6 +20,12 @@ export interface TransfersState {
   cycles_transferred?: number; 
 }
 
+export interface MemorySlice {
+  offset: number;
+  size: number;
+  data: string; // hex-encoded
+}
+
 export interface StreamingMultiprocessorState {
   id: number;
   blocks_active: number;


### PR DESCRIPTION
## Summary
- add `MemorySlice` type
- implement memory slice fetchers
- create `MemoryViewer` component
- integrate inspector in `GpuDetailView`
- test viewer

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685df5c4bb38833197b2de06328d51fc