### PR TITLE
Add kernel log endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,19 @@ cd app && npm install && npm run dev
 ```
 
 The dashboard makes periodic requests to `/gpus` to list available devices,
-`/gpus/<id>/state` for detailed metrics and `/events` for the event log. If you
+`/gpus/<id>/state` for detailed metrics, `/gpus/<id>/kernel_log` for the kernel launch history and `/events` for the consolidated event feed. If you
 want to confirm the API is responding during an example run you can query these
 endpoints manually using `curl`:
 
 ```bash
 curl http://localhost:8000/gpus
 curl http://localhost:8000/gpus/0/state
+curl http://localhost:8000/gpus/0/kernel_log
 curl http://localhost:8000/events
 ```
+
+In the dashboard, navigate to a GPU detail page and use the **Show Kernel Log**
+button to toggle a table listing all recorded kernel launches.
 
 ## Using with Jupyter/REPL
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,6 +4,7 @@ import { GPUState, SimulatorEvent, GpuSummary, BackendData, MemorySlice } from '
 import { fetchBackendData, fetchGpuState, fetchGlobalMemorySlice, fetchConstantMemorySlice } from './services/gpuSimulatorService';
 import { IconChip, IconMemory, IconActivity, IconInfo, IconChevronDown, IconChevronUp, Tooltip, MemoryUsageDisplay, SmCard, GpuOverviewCard, TransfersDisplay, EventLog, IconGpu, IconLink, StatDisplay } from './components/components';
 import { MemoryViewer } from './components/MemoryViewer';
+import { KernelLogView } from './components/KernelLogView';
 
 
 interface DashboardLayoutProps {
@@ -141,6 +142,7 @@ export const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => {
   const [memType, setMemType] = useState<'global' | 'constant'>('global');
   const [slice, setSlice] = useState<MemorySlice | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showKernelLog, setShowKernelLog] = useState(false);
 
   const fetchSlice = async () => {
     setLoading(true);
@@ -209,6 +211,13 @@ export const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => {
             </div>
             {loading && <p className="text-xs text-gray-400">Loading...</p>}
             {slice && <MemoryViewer slice={slice} />}
+            <button
+              onClick={() => setShowKernelLog((v) => !v)}
+              className="mt-4 px-2 py-1 bg-gray-700 rounded text-xs"
+            >
+              {showKernelLog ? 'Hide Kernel Log' : 'Show Kernel Log'}
+            </button>
+            {showKernelLog && <KernelLogView gpuId={gpu.id} />}
           </div>
       </div>
 

--- a/app/src/__tests__/KernelLogView.test.tsx
+++ b/app/src/__tests__/KernelLogView.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import { KernelLogView } from '../components/KernelLogView';
+import { KernelLaunchRecord } from '../types/types';
+import * as service from '../services/gpuSimulatorService';
+
+vi.mock('../services/gpuSimulatorService', () => ({
+  fetchKernelLog: vi.fn(),
+}));
+
+const mockFetch = service.fetchKernelLog as unknown as ReturnType<typeof vi.fn>;
+
+const log: KernelLaunchRecord[] = [
+  { name: 'dummy', grid_dim: [1, 1, 1], block_dim: [2, 2, 1], start_cycle: 5 },
+];
+
+describe('KernelLogView', () => {
+  it('renders kernel log entries', async () => {
+    mockFetch.mockResolvedValue(log);
+    render(<KernelLogView gpuId="0" />);
+    expect(await screen.findByText('dummy')).toBeInTheDocument();
+    expect(screen.getByText('1x1x1')).toBeInTheDocument();
+    expect(screen.getByText('2x2x1')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/KernelLogView.tsx
+++ b/app/src/components/KernelLogView.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { KernelLaunchRecord } from '../types/types';
+import { fetchKernelLog } from '../services/gpuSimulatorService';
+
+export const KernelLogView: React.FC<{ gpuId: string }> = ({ gpuId }) => {
+  const [log, setLog] = useState<KernelLaunchRecord[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+    fetchKernelLog(gpuId)
+      .then((entries) => {
+        if (isMounted) setLog(entries);
+      })
+      .catch((err) => console.error('Failed to fetch kernel log', err));
+    return () => {
+      isMounted = false;
+    };
+  }, [gpuId]);
+
+  if (log.length === 0) {
+    return <p className="text-gray-400">No kernel launches recorded.</p>;
+  }
+
+  return (
+    <table className="text-sm w-full mt-2">
+      <thead>
+        <tr className="text-left">
+          <th className="pr-4">Name</th>
+          <th className="pr-4">Grid</th>
+          <th className="pr-4">Block</th>
+          <th>Start Cycle</th>
+        </tr>
+      </thead>
+      <tbody>
+        {log.map((k, idx) => (
+          <tr key={idx} className="odd:bg-gray-800">
+            <td className="font-mono pr-4">{k.name}</td>
+            <td className="pr-4">{k.grid_dim.join('x')}</td>
+            <td className="pr-4">{k.block_dim.join('x')}</td>
+            <td>{k.start_cycle}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/app/src/services/gpuSimulatorService.ts
+++ b/app/src/services/gpuSimulatorService.ts
@@ -8,6 +8,7 @@ import {
   TransfersState,
   SMDetailed,
   MemorySlice,
+  KernelLaunchRecord,
 } from '../types/types';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE_URL || 'http://localhost:8000';
@@ -138,5 +139,11 @@ export const fetchConstantMemorySlice = async (
   return fetchJSON<MemorySlice>(
     `${API_BASE}/gpus/${gpuId}/constant_mem?offset=${offset}&size=${size}`,
   );
+};
+
+export const fetchKernelLog = async (
+  gpuId: string,
+): Promise<KernelLaunchRecord[]> => {
+  return fetchJSON<KernelLaunchRecord[]>(`${API_BASE}/gpus/${gpuId}/kernel_log`);
 };
 

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -55,6 +55,13 @@ export interface DivergenceRecord {
   mask_after: boolean[];
 }
 
+export interface KernelLaunchRecord {
+  name: string;
+  grid_dim: [number, number, number];
+  block_dim: [number, number, number];
+  start_cycle: number;
+}
+
 export interface MemorySlice {
   offset: number;
   size: number;

--- a/py_virtual_gpu/api/routers/gpus.py
+++ b/py_virtual_gpu/api/routers/gpus.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from ...services import GPUManager, get_gpu_manager
-from ..schemas import GPUSummary, GPUState, GPUMetrics, SMDetailed, MemorySlice
+from ..schemas import (
+    GPUSummary,
+    GPUState,
+    GPUMetrics,
+    SMDetailed,
+    MemorySlice,
+    KernelLaunchRecord,
+)
 
 router = APIRouter()
 
@@ -83,3 +90,12 @@ def constant_mem_slice(
     except IndexError:
         raise HTTPException(status_code=404, detail="Invalid GPU id or bounds")
     return MemorySlice(offset=offset, size=len(data), data=data.hex())
+
+
+@router.get("/gpus/{id}/kernel_log", response_model=list[KernelLaunchRecord])
+def kernel_log(
+    id: int, manager: GPUManager = Depends(get_gpu_manager)
+) -> list[KernelLaunchRecord]:
+    """Return the kernel launch log for GPU ``id``."""
+
+    return manager.get_kernel_log(id)

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -21,6 +21,15 @@ class TransferRecord(BaseModel):
     end_cycle: int
 
 
+class KernelLaunchRecord(BaseModel):
+    """Serialized kernel launch event."""
+
+    name: str
+    grid_dim: tuple[int, int, int]
+    block_dim: tuple[int, int, int]
+    start_cycle: int
+
+
 class GlobalMemState(BaseModel):
     """State of the GPU global memory."""
 

--- a/py_virtual_gpu/services/gpu_manager.py
+++ b/py_virtual_gpu/services/gpu_manager.py
@@ -166,6 +166,14 @@ class GPUManager:
         gpu = self.get_gpu(id)
         return gpu.constant_memory.read(offset, size)
 
+    def get_kernel_log(self, id: int):
+        """Return a list of kernel launch records for GPU ``id``."""
+
+        from ..api.schemas import KernelLaunchRecord
+
+        gpu = self.get_gpu(id)
+        return [KernelLaunchRecord(**asdict(ev)) for ev in gpu.get_kernel_log()]
+
     def get_event_feed(self, since_cycle: int | None = None, limit: int = 100):
         """Return a global event feed aggregated from all GPUs."""
 

--- a/tests/test_kernel_log_endpoint.py
+++ b/tests/test_kernel_log_endpoint.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import queue
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+
+
+def _setup_gpu():
+    manager = get_gpu_manager()
+    manager._gpus.clear()
+    gpu = VirtualGPU(num_sms=1, global_mem_size=64)
+    for sm in gpu.sms:
+        sm.block_queue = queue.Queue()
+    manager.add_gpu(gpu)
+    return gpu
+
+
+def test_kernel_log_endpoint():
+    gpu = _setup_gpu()
+
+    def dummy():
+        pass
+
+    gpu.launch_kernel(dummy, (1, 1, 1), (2, 2, 1))
+
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/kernel_log")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "dummy"
+        assert data[0]["grid_dim"] == [1, 1, 1]
+        assert data[0]["block_dim"] == [2, 2, 1]


### PR DESCRIPTION
## Summary
- provide KernelLaunchRecord schema
- expose `/gpus/{id}/kernel_log` endpoint
- support fetching kernel log in GPUManager
- add KernelLogView component with tests
- show/hide kernel log on GPU detail page
- document new endpoint and UI usage
- add test for new endpoint

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e0bb080e08331b4a28e03bcb742d9