### PR TITLE
Add notebook helper to launch dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,14 +140,16 @@ button to toggle a table listing all recorded kernel launches.
 To expose the API while working interactively start it in a background thread:
 
 ```python
-from py_virtual_gpu.api.server import start_background_api
+from py_virtual_gpu.api.server import start_background_api, start_background_dashboard
 
-thread, stop = start_background_api(port=8001)
-# ... interact with the API ...
+api_thread, ui_proc, stop = start_background_dashboard(port=8001)
+# ... interact with the API/UI ...
 stop()
 ```
-
-This is helpful when running notebooks or experimenting in the Python REPL.
+This is helpful when running notebooks or experimenting in the Python REPL. The
+``start_background_dashboard`` helper launches both the FastAPI server and the
+React dashboard with a single call. If you only need the API server use
+``start_background_api`` instead.
 
 ## Setup de desenvolvimento
 

--- a/py_virtual_gpu/api/__init__.py
+++ b/py_virtual_gpu/api/__init__.py
@@ -1,6 +1,5 @@
 """FastAPI application for py_virtual_gpu."""
 
 from .main import app
-from .server import start_background_api
-
-__all__ = ["app", "start_background_api"]
+from .server import start_background_api, start_background_dashboard
+__all__ = ["app", "start_background_api", "start_background_dashboard"]


### PR DESCRIPTION
## Summary
- expose a helper that starts the API and React dashboard together
- export the helper from `py_virtual_gpu.api`
- document the helper usage in the README
- cover the new helper with tests

## Testing
- `pip install -e .[api]`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e82ad6bb48331af40e203de7278f4