### PR TITLE
Fix missing import path

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -1,7 +1,12 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { GPUState, SimulatorEvent, GpuSummary, BackendData, MemorySlice } from './types/types';
-import { fetchBackendData, fetchGpuState, fetchGlobalMemorySlice, fetchConstantMemorySlice } from './services/gpuSimulatorService';
+import {
+  fetchBackendData,
+  fetchGpuState,
+  fetchGlobalMemorySlice,
+  fetchConstantMemorySlice,
+} from './gpuSimulatorService';
 import { IconChip, IconMemory, IconActivity, IconInfo, IconChevronDown, IconChevronUp, Tooltip, MemoryUsageDisplay, SmCard, GpuOverviewCard, TransfersDisplay, EventLog, IconGpu, IconLink, StatDisplay } from './components/components';
 import { MemoryViewer } from './components/MemoryViewer';
 import { KernelLogView } from './components/KernelLogView';

--- a/app/KernelLogView.tsx
+++ b/app/KernelLogView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { KernelLaunchRecord } from '../types/types';
-import { fetchKernelLog } from '../services/gpuSimulatorService';
+import { fetchKernelLog } from './gpuSimulatorService';
 
 export const KernelLogView: React.FC<{ gpuId: string }> = ({ gpuId }) => {
   const [log, setLog] = useState<KernelLaunchRecord[]>([]);

--- a/app/components.tsx
+++ b/app/components.tsx
@@ -8,7 +8,7 @@ import {
   TransfersState,
   SMDetailed,
 } from '../types/types';
-import { fetchSmDetail } from '../services/gpuSimulatorService';
+import { fetchSmDetail } from './gpuSimulatorService';
 import { SmDetailView } from './SmDetailView';
 
 // --- Icons ---


### PR DESCRIPTION
## Summary
- correct GPU service paths in React source
- run vitest and pytest to ensure tests pass

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9b2693c08331a9c81543757105d0