### PR TITLE
Add SM block events to API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ their progress.
 ```bash
 # plain execution
 python examples/vector_mul.py
+python examples/matrix_mul.py
 
 # start with API support to visualize in the UI
 python examples/vector_mul.py --api
+python examples/matrix_mul.py --api
 ```
 
 When ``--api`` is used the script launches the FastAPI server in the background

--- a/app/SmDetailView.tsx
+++ b/app/SmDetailView.tsx
@@ -29,5 +29,15 @@ export const SmDetailView: React.FC<{ sm: SMDetailed }> = ({ sm }) => (
         </ul>
       )}
     </div>
+    {sm.block_event_log && sm.block_event_log.length > 0 && (
+      <div className="mt-2">
+        <h5 className="font-semibold text-sky-300">Block Events</h5>
+        <ul className="list-disc list-inside text-xs">
+          {sm.block_event_log.map((ev, idx) => (
+            <li key={idx}>Block [{ev.block_idx.join(', ')}] {ev.phase} at cycle {ev.start_cycle}</li>
+          ))}
+        </ul>
+      </div>
+    )}
   </div>
 );

--- a/app/gpuSimulatorService.ts
+++ b/app/gpuSimulatorService.ts
@@ -93,6 +93,7 @@ export const fetchSmDetail = async (
     warps: detail.warps ?? [],
     divergence_log: detail.divergence_log ?? [],
     counters: detail.counters ?? {},
+    block_event_log: detail.block_event_log ?? [],
   };
 };
 

--- a/app/src/__tests__/SmCard.test.tsx
+++ b/app/src/__tests__/SmCard.test.tsx
@@ -36,6 +36,7 @@ const detail: SMDetailed = {
   warps: [],
   divergence_log: [],
   counters: {},
+  block_event_log: [],
 };
 
 describe('SmCard', () => {

--- a/app/src/__tests__/SmDetailView.test.tsx
+++ b/app/src/__tests__/SmDetailView.test.tsx
@@ -11,9 +11,14 @@ describe('SmDetailView', () => {
       warps: [{ id: 1, active_threads: 32 }],
       divergence_log: [],
       counters: {},
+      block_event_log: [
+        { block_idx: [0, 0, 0], sm_id: 0, phase: 'start', start_cycle: 1 },
+      ],
     };
     render(<SmDetailView sm={detail} />);
     expect(screen.getByText(/Block \[0, 0, 0\] - pending/)).toBeInTheDocument();
     expect(screen.getByText(/Warp 1: 32 threads active/)).toBeInTheDocument();
+    expect(screen.getByText(/Block \[0, 0, 0\] start/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cycle 1/)).toBeInTheDocument();
   });
 });

--- a/app/src/components/SmDetailView.tsx
+++ b/app/src/components/SmDetailView.tsx
@@ -62,5 +62,22 @@ export const SmDetailView: React.FC<{ sm: SMDetailed }> = ({ sm }) => (
         </div>
       </div>
     )}
+
+    {sm.block_event_log && sm.block_event_log.length > 0 && (
+      <div>
+        <h5 className="font-semibold text-sky-300 mb-2 flex items-center">
+          <span className="w-2 h-2 bg-blue-400 rounded-full mr-2"></span>
+          Block Events
+        </h5>
+        <div className="ml-4 space-y-1 text-xs">
+          {sm.block_event_log.map((ev, idx) => (
+            <div key={idx} className="flex justify-between bg-gray-600 px-2 py-1 rounded">
+              <span>Block [{ev.block_idx.join(', ')}] {ev.phase}</span>
+              <span>Cycle {ev.start_cycle}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    )}
   </div>
 );

--- a/app/src/services/gpuSimulatorService.ts
+++ b/app/src/services/gpuSimulatorService.ts
@@ -93,6 +93,7 @@ export const fetchSmDetail = async (
     warps: detail.warps ?? [],
     divergence_log: detail.divergence_log ?? [],
     counters: detail.counters ?? {},
+    block_event_log: detail.block_event_log ?? [],
   };
 };
 

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -55,6 +55,13 @@ export interface DivergenceRecord {
   mask_after: boolean[];
 }
 
+export interface BlockEventRecord {
+  block_idx: [number, number, number];
+  sm_id: number;
+  phase: string;
+  start_cycle: number;
+}
+
 export interface KernelLaunchRecord {
   name: string;
   grid_dim: [number, number, number];
@@ -74,6 +81,7 @@ export interface SMDetailed {
   warps: WarpSummary[];
   divergence_log: DivergenceRecord[];
   counters: Record<string, number>;
+  block_event_log: BlockEventRecord[];
 }
 
 export interface GPUState {

--- a/app/types.ts
+++ b/app/types.ts
@@ -55,6 +55,13 @@ export interface DivergenceRecord {
   mask_after: boolean[];
 }
 
+export interface BlockEventRecord {
+  block_idx: [number, number, number];
+  sm_id: number;
+  phase: string;
+  start_cycle: number;
+}
+
 export interface KernelLaunchRecord {
   name: string;
   grid_dim: [number, number, number];
@@ -74,6 +81,7 @@ export interface SMDetailed {
   warps: WarpSummary[];
   divergence_log: DivergenceRecord[];
   counters: Record<string, number>;
+  block_event_log: BlockEventRecord[];
 }
 
 export interface GPUState {

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Execute the scripts directly with Python:
 ```bash
 python examples/vector_mul.py
 python examples/convolution_2d.py
+python examples/matrix_mul.py
 ```
 
 Each program allocates memory on the virtual device, launches a kernel and prints
@@ -16,7 +17,7 @@ whether the result computed on the device matches the host computation.
 
 ### Visualizing via API and UI
 
-Both examples accept the ``--api`` flag to start the FastAPI server while they
+All examples accept the ``--api`` flag to start the FastAPI server while they
 run. When the server is active you can launch the dashboard UI from the
 ``app`` directory:
 
@@ -28,6 +29,7 @@ Then run an example with API support enabled:
 
 ```bash
 python examples/vector_mul.py --api
+python examples/matrix_mul.py --api
 ```
 
 Open ``http://localhost:5173`` to inspect the execution step by step through the

--- a/examples/matrix_mul.py
+++ b/examples/matrix_mul.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.api.server import start_background_api
+from py_virtual_gpu.kernel import kernel
+
+
+@kernel(grid_dim=(1, 1, 1), block_dim=(2, 2, 1))
+def mat_mul(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, c_ptr, n):
+    col, row, _ = threadIdx
+    acc = 0
+    for k in range(n):
+        a = int.from_bytes(a_ptr[row * n + k], "little", signed=True)
+        b = int.from_bytes(b_ptr[k * n + col], "little", signed=True)
+        acc += a * b
+    c_ptr[row * n + col] = acc.to_bytes(4, "little", signed=True)
+
+
+def host_mat_mul(A, B):
+    n = len(A)
+    C = [[0 for _ in range(n)] for _ in range(n)]
+    for i in range(n):
+        for j in range(n):
+            for k in range(n):
+                C[i][j] += A[i][k] * B[k][j]
+    return C
+
+
+def main(with_api: bool = False) -> None:
+    if with_api:
+        api_thread, stop_api = start_background_api()
+    else:
+        api_thread = stop_api = None
+
+    n = 2
+    gpu = VirtualGPU(num_sms=1, global_mem_size=128)
+    get_gpu_manager().add_gpu(gpu)
+    VirtualGPU.set_current(gpu)
+
+    A = [[1, 2], [3, 4]]
+    B = [[5, 6], [7, 8]]
+    expected = host_mat_mul(A, B)
+    flat_A = [v for row in A for v in row]
+    flat_B = [v for row in B for v in row]
+    a_bytes = b"".join(v.to_bytes(4, "little", signed=True) for v in flat_A)
+    b_bytes = b"".join(v.to_bytes(4, "little", signed=True) for v in flat_B)
+
+    a_ptr = gpu.malloc(len(a_bytes))
+    b_ptr = gpu.malloc(len(b_bytes))
+    c_ptr = gpu.malloc(len(a_bytes))
+
+    gpu.memcpy_host_to_device(a_bytes, a_ptr)
+    gpu.memcpy_host_to_device(b_bytes, b_ptr)
+
+    mat_mul(a_ptr, b_ptr, c_ptr, n)
+    gpu.synchronize()
+
+    out = gpu.memcpy_device_to_host(c_ptr, len(a_bytes))
+    result = [int.from_bytes(out[i * 4:(i + 1) * 4], "little", signed=True) for i in range(n * n)]
+    expected_flat = [v for row in expected for v in row]
+
+    print("Kernel result:", result)
+    print("Host result:", expected_flat)
+
+    if stop_api:
+        stop_api()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Matrix multiplication example")
+    parser.add_argument("--api", action="store_true", help="start API server while running")
+    args = parser.parse_args()
+    main(with_api=args.api)

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -103,6 +103,15 @@ class DivergenceRecord(BaseModel):
     mask_after: list[bool]
 
 
+class BlockEventRecord(BaseModel):
+    """Serialized record of a thread block event."""
+
+    block_idx: tuple[int, int, int]
+    sm_id: int
+    phase: str
+    start_cycle: int
+
+
 class SMDetailed(BaseModel):
     """Detailed information for a single StreamingMultiprocessor."""
 
@@ -111,6 +120,7 @@ class SMDetailed(BaseModel):
     warps: list[WarpSummary]
     divergence_log: list[DivergenceRecord]
     counters: dict[str, int]
+    block_event_log: list[BlockEventRecord]
 
 
 class MemorySlice(BaseModel):

--- a/tests/test_events_endpoint.py
+++ b/tests/test_events_endpoint.py
@@ -34,10 +34,13 @@ def test_events_endpoint_returns_all():
         pass
 
     gpu.launch_kernel(dummy, (1, 1, 1), (1, 1, 1))
+    gpu.synchronize()
 
     with TestClient(app) as client:
         resp = client.get("/events")
         assert resp.status_code == 200
         data = resp.json()
-        assert len(data) == 4
+        assert len(data) == 6
         assert data == sorted(data, key=lambda e: e["start_cycle"])
+        types = {ev["type"] for ev in data}
+        assert {"kernel", "transfer", "divergence", "BLOCK_START", "BLOCK_END"} <= types

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -28,3 +28,10 @@ def test_convolution_example(capsys):
     mod.main()
     kernel, host = _parse_results(capsys.readouterr().out)
     assert kernel == host
+
+
+def test_matrix_mul_example(capsys):
+    mod = importlib.import_module("examples.matrix_mul")
+    mod.main()
+    kernel, host = _parse_results(capsys.readouterr().out)
+    assert kernel == host

--- a/tests/test_sm_detail_endpoint.py
+++ b/tests/test_sm_detail_endpoint.py
@@ -40,3 +40,4 @@ def test_sm_detail_divergence_log_size():
         assert resp.status_code == 200
         data = resp.json()
         assert data["counters"]["warp_divergences"] == len(data["divergence_log"])
+        assert "block_event_log" in data


### PR DESCRIPTION
## Summary
- expose block execution events in SMDetailed schema
- fetch block event log via GPU manager
- render block events in SmDetailView component
- adjust front-end types and tests
- verify SM detail endpoint returns block events

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec80289b88331bb54c10bc8fd18a7