### PR TITLE
Add syncthreads helper and update examples

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -6,6 +6,7 @@ from .memory import DevicePointer
 from .streaming_multiprocessor import StreamingMultiprocessor, DivergenceEvent
 from .thread_block import ThreadBlock
 from .warp import Warp, is_coalesced
+from .sync import syncthreads
 from .dispatch import Instruction, SIMTStack
 from .transfer import TransferEvent
 from .atomics import (
@@ -61,5 +62,6 @@ __all__ = [
     "atomicMax",
     "atomicMin",
     "atomicExchange",
+    "syncthreads",
 ]
 

--- a/py_virtual_gpu/sync.py
+++ b/py_virtual_gpu/sync.py
@@ -1,0 +1,12 @@
+from .thread import get_current_thread
+
+
+def syncthreads() -> None:
+    """Synchronize all threads in the current block."""
+    thread = get_current_thread()
+    if thread is None:
+        raise RuntimeError("syncthreads() must be called from a GPU thread")
+    thread.barrier.wait()
+
+
+__all__ = ["syncthreads"]


### PR DESCRIPTION
## Summary
- add `syncthreads()` helper to wait on a thread's barrier
- expose `syncthreads` from the package
- update example kernels to call `syncthreads()` instead of using the context barrier directly

## Testing
- `pip install -e .[api]`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f41a21b7483319e11f9dbb609a7a2