### PR TITLE
Add memory fence helpers

### DIFF
--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -84,6 +84,21 @@ def vec_mul(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):
 - A classe `SharedMemory` expõe operações atômicas (`atomic_add`, `atomic_sub`,
   `atomic_cas`, `atomic_max`, `atomic_min`, `atomic_exchange`) que permitem
   atualização segura de valores compartilhados entre threads.
+
+## Fences de Memória
+
+Três funções simulam as barreiras de memória do CUDA para controlar a
+visibilidade de escritas:
+
+- `threadfence_block()` garante que dados gravados na `SharedMemory` do bloco
+  fiquem visíveis aos demais threads do mesmo block após o fence.
+- `threadfence()` propaga atualizações para todas as memórias acessíveis dentro
+  do dispositivo, cobrindo tanto a `SharedMemory` quanto a `GlobalMemory`.
+- `threadfence_system()` estende o efeito para que a aplicação hospedeira possa
+  observar as escritas; na simulação ele é equivalente a `threadfence()`.
+
+Em todos os casos essas funções apenas adquirem e liberam os locks das
+respectivas memórias para emular o efeito de ordenação.
 ## Operações Atômicas
 
 A biblioteca também fornece *helpers* de alto nível para realizar operações atômicas diretamente sobre ``DevicePointer`` na ``GlobalMemory``. As funções ``atomicAdd``, ``atomicSub``, ``atomicCAS``, ``atomicMax``, ``atomicMin`` e ``atomicExchange`` recebem o ponteiro e o valor desejado, retornando o valor anterior.

--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -7,6 +7,7 @@ from .streaming_multiprocessor import StreamingMultiprocessor, DivergenceEvent
 from .thread_block import ThreadBlock
 from .warp import Warp, is_coalesced
 from .sync import syncthreads
+from .fence import threadfence_block, threadfence, threadfence_system
 from .dispatch import Instruction, SIMTStack
 from .transfer import TransferEvent
 from .atomics import (
@@ -63,5 +64,8 @@ __all__ = [
     "atomicMin",
     "atomicExchange",
     "syncthreads",
+    "threadfence_block",
+    "threadfence",
+    "threadfence_system",
 ]
 

--- a/py_virtual_gpu/fence.py
+++ b/py_virtual_gpu/fence.py
@@ -1,0 +1,53 @@
+"""Memory fence helpers mimicking CUDA semantics."""
+
+from __future__ import annotations
+
+from .thread import get_current_thread
+
+__all__ = [
+    "threadfence_block",
+    "threadfence",
+    "threadfence_system",
+]
+
+
+def threadfence_block() -> None:
+    """Fence writes within the current block's shared memory.
+
+    In this simulator the fence simply acquires and releases the
+    :class:`SharedMemory` lock of the calling thread to mimic the
+    ordering guarantees of ``__threadfence_block`` in CUDA.
+    """
+
+    thread = get_current_thread()
+    if thread is None:
+        raise RuntimeError("threadfence_block() must be called from a GPU thread")
+    if getattr(thread, "shared_mem", None) is None:
+        return
+    with thread.shared_mem.lock:
+        pass
+
+
+def threadfence() -> None:
+    """Fence writes to shared and global memory for the whole device."""
+
+    thread = get_current_thread()
+    if thread is None:
+        raise RuntimeError("threadfence() must be called from a GPU thread")
+
+    if getattr(thread, "global_mem", None) is not None:
+        with thread.global_mem.lock:
+            pass
+    if getattr(thread, "shared_mem", None) is not None:
+        with thread.shared_mem.lock:
+            pass
+
+
+def threadfence_system() -> None:
+    """Fence writes so that host threads observe them.
+
+    Host and device share memory in this simulator, so this currently
+    behaves the same as :func:`threadfence`.
+    """
+
+    threadfence()

--- a/tests/test_fence.py
+++ b/tests/test_fence.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.thread import Thread
+from py_virtual_gpu.shared_memory import SharedMemory
+from py_virtual_gpu.global_memory import GlobalMemory
+from py_virtual_gpu.fence import threadfence_block, threadfence, threadfence_system
+
+
+def test_threadfence_block_acquires_lock():
+    sm = SharedMemory(4)
+    t = Thread((0, 0, 0), (0, 0, 0), (1, 1, 1), (1, 1, 1), 0, shared_mem=sm)
+
+    mock = MagicMock()
+    mock.__enter__.return_value = None
+    mock.__exit__.return_value = None
+    sm.lock = mock
+
+    def kernel(tidx, bidx, bdim, gdim):
+        threadfence_block()
+
+    t.run(kernel, t.thread_idx, t.block_idx, t.block_dim, t.grid_dim)
+    assert mock.__enter__.called
+    assert mock.__exit__.called
+
+
+def test_threadfence_acquires_global_lock():
+    gm = GlobalMemory(4)
+    t = Thread((0, 0, 0), (0, 0, 0), (1, 1, 1), (1, 1, 1), 0, global_mem=gm)
+
+    mock = MagicMock()
+    mock.__enter__.return_value = None
+    mock.__exit__.return_value = None
+    gm.lock = mock
+
+    def kernel(tidx, bidx, bdim, gdim):
+        threadfence()
+
+    t.run(kernel, t.thread_idx, t.block_idx, t.block_dim, t.grid_dim)
+    assert mock.__enter__.called
+    assert mock.__exit__.called
+
+
+def test_threadfence_system_alias():
+    gm = GlobalMemory(4)
+    t = Thread((0, 0, 0), (0, 0, 0), (1, 1, 1), (1, 1, 1), 0, global_mem=gm)
+
+    def kernel(tidx, bidx, bdim, gdim):
+        gm.write(0, b"\x05")
+        threadfence_system()
+
+    t.run(kernel, t.thread_idx, t.block_idx, t.block_dim, t.grid_dim)
+    assert gm.read(0, 1) == b"\x05"
+
+from py_virtual_gpu.thread_block import ThreadBlock
+
+
+def test_threadfence_block_orders_writes_between_threads():
+    tb = ThreadBlock((0, 0, 0), (2, 1, 1), (1, 1, 1), shared_mem_size=1)
+    results = [0, 0]
+
+    def kernel(tidx, bidx, bdim, gdim, barrier, out):
+        if tidx[0] == 0:
+            tb.shared_mem.write(0, b"\x07")
+            threadfence_block()
+        barrier.wait()
+        out[tidx[0]] = tb.shared_mem.read(0, 1)[0]
+
+    tb.execute(kernel, tb.barrier, results)
+    assert results[1] == 7


### PR DESCRIPTION
## Summary
- introduce `threadfence_block`, `threadfence` and `threadfence_system`
- document when to use each fence
- expose fence helpers in the main package
- test fence lock usage and ordering semantics

## Testing
- `pip install fastapi uvicorn[standard] httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4311f7c4833181201d2dd305a706