### PR TITLE
Add barrier synchronization timeout

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -10,6 +10,7 @@ from .sync import syncthreads
 from .fence import threadfence_block, threadfence, threadfence_system
 from .dispatch import Instruction, SIMTStack
 from .transfer import TransferEvent
+from .errors import SynchronizationError
 from .atomics import (
     atomicAdd,
     atomicSub,
@@ -57,6 +58,7 @@ __all__ = [
     "HostMemory",
     "TransferEvent",
     "KernelLaunchEvent",
+    "SynchronizationError",
     "atomicAdd",
     "atomicSub",
     "atomicCAS",

--- a/py_virtual_gpu/errors.py
+++ b/py_virtual_gpu/errors.py
@@ -1,0 +1,4 @@
+class SynchronizationError(RuntimeError):
+    """Raised when a barrier synchronization fails or times out."""
+
+__all__ = ["SynchronizationError"]


### PR DESCRIPTION
## Summary
- add custom SynchronizationError class
- implement optional timeout for ThreadBlock barriers and propagate to threads
- expose timeout parameter in VirtualGPU
- raise SynchronizationError when a barrier times out
- test barrier timeout behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f44a8914883318b9d27d861206330