### PR TITLE
Add cooperative grid sync

### DIFF
--- a/py_virtual_gpu/kernel.py
+++ b/py_virtual_gpu/kernel.py
@@ -32,12 +32,20 @@ class KernelFunction:
     def __call__(self, *args: object, **kwargs: object) -> object:
         gd = self.grid_dim or kwargs.pop("grid_dim", None)
         bd = self.block_dim or kwargs.pop("block_dim", None)
+        cooperative = kwargs.pop("cooperative", False)
         if gd is None or bd is None:
             raise TypeError(
                 f"Kernel '{self.__name__}' requires grid_dim and block_dim"
             )
         gpu = VirtualGPU.get_current()
-        return gpu.launch_kernel(self._func, gd, bd, *args, **kwargs)
+        return gpu.launch_kernel(
+            self._func,
+            gd,
+            bd,
+            *args,
+            cooperative=cooperative,
+            **kwargs,
+        )
 
 
 def kernel(

--- a/py_virtual_gpu/sync.py
+++ b/py_virtual_gpu/sync.py
@@ -14,5 +14,20 @@ def syncthreads() -> None:
     except BrokenBarrierError as exc:
         raise SynchronizationError("Barrier wait timed out") from exc
 
+def sync_grid() -> None:
+    """Synchronize all threads in the current grid."""
 
-__all__ = ["syncthreads"]
+    thread = get_current_thread()
+    if thread is None:
+        raise RuntimeError("sync_grid() must be called from a GPU thread")
+    barrier = getattr(thread, "grid_barrier", None)
+    if barrier is None:
+        raise RuntimeError("Kernel was not launched cooperatively")
+    timeout = getattr(thread, "grid_barrier_timeout", None)
+    try:
+        barrier.wait(timeout=timeout)
+    except BrokenBarrierError as exc:
+        raise SynchronizationError("Barrier wait timed out") from exc
+
+
+__all__ = ["syncthreads", "sync_grid"]

--- a/tests/test_grid_sync.py
+++ b/tests/test_grid_sync.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.virtualgpu import VirtualGPU
+from py_virtual_gpu.sync import sync_grid
+from py_virtual_gpu.errors import SynchronizationError
+
+
+def test_sync_grid_success():
+    gpu = VirtualGPU(0, 32, barrier_timeout=0.1)
+
+    records = []
+
+    def kernel(tidx, bidx, bdim, gdim, log):
+        log.append(("before", tidx))
+        sync_grid()
+        log.append(("after", tidx))
+
+    gpu.launch_kernel(kernel, (1, 1, 1), (2, 1, 1), records, cooperative=True)
+
+    total_threads = 2
+    assert len(records) == 2 * total_threads
+    before = [i for i, r in enumerate(records) if r[0] == "before"]
+    after = [i for i, r in enumerate(records) if r[0] == "after"]
+    assert len(before) == total_threads
+    assert len(after) == total_threads
+    assert min(after) > max(before)
+
+
+def test_sync_grid_missing_thread_raises():
+    gpu = VirtualGPU(0, 32, barrier_timeout=0.05)
+    errors = []
+
+    def kernel(tidx, bidx, bdim, gdim, log):
+        if tidx[0] == 0:
+            return
+        try:
+            sync_grid()
+        except SynchronizationError:
+            log.append(tidx)
+
+    gpu.launch_kernel(kernel, (1, 1, 1), (2, 1, 1), errors, cooperative=True)
+
+    assert errors == [(1, 0, 0)]


### PR DESCRIPTION
## Summary
- support cooperative kernel launches with grid-wide barriers
- expose `sync_grid()` for kernel code
- test successful and failing grid synchronization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4638fb8883319e61c3ba59fdac05