### PR TITLE
Add barrier wait metric

### DIFF
--- a/app/src/components/components.tsx
+++ b/app/src/components/components.tsx
@@ -210,6 +210,7 @@ export const SmCard: React.FC<SmCardProps> = ({ sm, gpuId }) => {
         <StatDisplay label="Warp Divergences" value={sm.warp_divergences} />
         <StatDisplay label="Bank Conflicts" value={sm.bank_conflicts} />
         <StatDisplay label="Non-Coalesced" value={sm.non_coalesced_accesses} />
+        <StatDisplay label="Barrier Wait" value={sm.barrier_wait_ms} unit="ms" />
         {sm.shared_mem_total_kb > 0 && (
           <StatDisplay label="Shared Mem" value={`${sm.shared_mem_usage_kb}/${sm.shared_mem_total_kb}`} unit="KB"/>
         )}

--- a/app/src/services/gpuSimulatorService.ts
+++ b/app/src/services/gpuSimulatorService.ts
@@ -35,6 +35,7 @@ function mapSmState(sm: any): StreamingMultiprocessorState {
     registers_used: undefined,
     registers_total: undefined,
     bank_conflicts: counters.bank_conflicts ?? 0,
+    barrier_wait_ms: counters.barrier_wait_ms ?? 0,
     active_block_idx: undefined,
     status: (sm.status || 'idle') as 'running' | 'idle' | 'waiting' | 'error',
     load_percentage: undefined,

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -31,8 +31,9 @@ export interface StreamingMultiprocessorState {
   shared_mem_total_kb: number; 
   registers_used?: number;
   registers_total?: number;
-  bank_conflicts: number; 
-  active_block_idx?: string; 
+  bank_conflicts: number;
+  barrier_wait_ms: number;
+  active_block_idx?: string;
   status: 'running' | 'idle' | 'waiting' | 'error';
   load_percentage?: number; // 0-100
   active_warps?: { id: number; active_threads: number; total_threads: number; pc?: number; status?: string }[];

--- a/py_virtual_gpu/streaming_multiprocessor.py
+++ b/py_virtual_gpu/streaming_multiprocessor.py
@@ -62,6 +62,7 @@ class StreamingMultiprocessor:
             "warp_divergences": 0,
             "non_coalesced_accesses": 0,
             "bank_conflicts": 0,
+            "barrier_wait_ms": 0,
         }
         self.stats: Dict[str, int] = {"extra_cycles": 0}
         self.divergence_log: List[DivergenceEvent] = []
@@ -94,6 +95,7 @@ class StreamingMultiprocessor:
             block.execute(func, *args)
             num_warps = (len(block.threads) + self.warp_size - 1) // self.warp_size
             self.counters["warps_executed"] += num_warps
+            self.counters["barrier_wait_ms"] += int(getattr(block, "barrier_wait_time", 0.0) * 1000)
             if self.gpu is not None:
                 self.gpu._cycle_counter += 1
             idx = getattr(block, "block_idx", (0, 0, 0))
@@ -118,6 +120,7 @@ class StreamingMultiprocessor:
         else:
             self.dispatch()
 
+        self.counters["barrier_wait_ms"] += int(getattr(block, "barrier_wait_time", 0.0) * 1000)
         if self.gpu is not None:
             self.gpu._cycle_counter += 1
         idx = getattr(block, "block_idx", (0, 0, 0))

--- a/py_virtual_gpu/sync.py
+++ b/py_virtual_gpu/sync.py
@@ -8,6 +8,10 @@ def syncthreads() -> None:
     thread = get_current_thread()
     if thread is None:
         raise RuntimeError("syncthreads() must be called from a GPU thread")
+    block = getattr(thread, "block", None)
+    if block is not None:
+        block.barrier_sync()
+        return
     timeout = getattr(thread, "barrier_timeout", None)
     try:
         thread.barrier.wait(timeout=timeout)

--- a/tests/test_gpu_state_endpoint.py
+++ b/tests/test_gpu_state_endpoint.py
@@ -35,6 +35,7 @@ def test_state_endpoint_idle():
         for sm in data["sms"]:
             assert sm["status"] == "idle"
             assert sm["counters"]["warps_executed"] == 0
+            assert "barrier_wait_ms" in sm["counters"]
 
 
 @pytest.mark.parametrize("policy", ["sequential", "round_robin"])

--- a/tests/test_sm_detail_endpoint.py
+++ b/tests/test_sm_detail_endpoint.py
@@ -41,3 +41,4 @@ def test_sm_detail_divergence_log_size():
         data = resp.json()
         assert data["counters"]["warp_divergences"] == len(data["divergence_log"])
         assert "block_event_log" in data
+        assert "barrier_wait_ms" in data["counters"]


### PR DESCRIPTION
## Summary
- accumulate barrier wait times inside ThreadBlock
- surface barrier_wait_ms through StreamingMultiprocessor counters
- forward barrier_sync via `syncthreads()`
- display metric in the dashboard SM cards
- adjust tests for new behavior

## Testing
- `pip install fastapi uvicorn[standard] httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f477a37288331955f5cd0ea0e9f57