### PR TITLE
Fix warp_utils manager initialization for Windows

### DIFF
--- a/py_virtual_gpu/thread_block.py
+++ b/py_virtual_gpu/thread_block.py
@@ -114,6 +114,9 @@ class ThreadBlock:
             environments where process forking is undesirable.
         """
         self.initialize_threads(kernel_func, *args)
+        # Ensure warp utilities are ready before spawning processes
+        from . import warp_utils
+        warp_utils._ensure_manager()
         Worker = _PyThread if use_threads else Process
         workers: List[Worker] = []
         for t in self.threads:

--- a/py_virtual_gpu/warp_utils.py
+++ b/py_virtual_gpu/warp_utils.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from multiprocessing import Lock, Manager
+from multiprocessing import Lock
+from multiprocessing.managers import SyncManager
 from typing import Any
+import os
+import json
 
 from .thread import get_current_thread
 
@@ -9,10 +12,37 @@ __all__ = ["shfl_sync", "ballot_sync"]
 
 # Shared dictionaries keyed by Barrier instances used by the threads. Each entry
 # is cleared once all threads of the warp have read the result.
-_manager = Manager()
-_shfl_values = _manager.dict()  # type: ignore[var-annotated]
-_ballot_values = _manager.dict()  # type: ignore[var-annotated]
+_manager = None  # type: ignore[var-annotated]
+_shfl_values = None  # type: ignore[var-annotated]
+_ballot_values = None  # type: ignore[var-annotated]
 _lock = Lock()
+
+
+def _ensure_manager() -> None:
+    """Lazily create or connect to the shared ``SyncManager`` instance."""
+    global _manager, _shfl_values, _ballot_values
+    if _manager is not None:
+        return
+
+    addr_json = os.environ.get("PYVGPU_MANAGER_ADDRESS")
+    auth_hex = os.environ.get("PYVGPU_MANAGER_AUTH")
+    if addr_json is None or auth_hex is None:
+        # Main process: start a new manager and expose its address
+        manager = SyncManager()
+        manager.start()
+        address = manager.address
+        os.environ["PYVGPU_MANAGER_ADDRESS"] = json.dumps(address)
+        os.environ["PYVGPU_MANAGER_AUTH"] = manager._authkey.hex()
+        _manager = manager
+    else:
+        address = json.loads(addr_json)
+        authkey = bytes.fromhex(auth_hex)
+        manager = SyncManager(address=tuple(address) if isinstance(address, list) else address, authkey=authkey)
+        manager.connect()
+        _manager = manager
+
+    _shfl_values = _manager.dict()  # type: ignore[assignment]
+    _ballot_values = _manager.dict()  # type: ignore[assignment]
 
 
 def shfl_sync(value: Any, src_lane: int) -> Any:
@@ -22,6 +52,7 @@ def shfl_sync(value: Any, src_lane: int) -> Any:
     local ``value``. The function waits for every thread to contribute and then
     returns the value provided by ``src_lane``.
     """
+    _ensure_manager()
     thread = get_current_thread()
     if thread is None:
         raise RuntimeError("shfl_sync() must be called from a GPU thread")
@@ -32,7 +63,7 @@ def shfl_sync(value: Any, src_lane: int) -> Any:
     key = id(barrier)
     lane = thread.thread_idx[0]
     with _lock:
-        if key not in _shfl_values:
+        if key not in _shfl_values:  # type: ignore[operator]
             _shfl_values[key] = _manager.dict()  # type: ignore[index]
         buf = _shfl_values[key]
         buf[lane] = value
@@ -48,6 +79,7 @@ def shfl_sync(value: Any, src_lane: int) -> Any:
 
 def ballot_sync(predicate: bool) -> int:
     """Collect predicates from all warp threads into a bit mask."""
+    _ensure_manager()
     thread = get_current_thread()
     if thread is None:
         raise RuntimeError("ballot_sync() must be called from a GPU thread")
@@ -58,7 +90,7 @@ def ballot_sync(predicate: bool) -> int:
     key = id(barrier)
     lane = thread.thread_idx[0]
     with _lock:
-        if key not in _ballot_values:
+        if key not in _ballot_values:  # type: ignore[operator]
             _ballot_values[key] = _manager.dict()  # type: ignore[index]
         buf = _ballot_values[key]
         buf[lane] = bool(predicate)


### PR DESCRIPTION
## Summary
- lazily create SyncManager and connect via environment variables
- ensure manager is started before spawning worker processes

## Testing
- `pytest -q`
- `pytest tests/test_warp_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685fee0525648331ab43d9f29cbeb520