### PR TITLE
DevicePointer uses owning memory

### DIFF
--- a/py_virtual_gpu/memory.py
+++ b/py_virtual_gpu/memory.py
@@ -38,24 +38,18 @@ class DevicePointer:
     # Memory access helpers
     # ------------------------------------------------------------------
     def __getitem__(self, index: int) -> bytes:
-        """Return the element at ``index`` from the current device's global memory."""
-
-        from .virtualgpu import VirtualGPU
+        """Return the element at ``index`` from ``self.memory``."""
 
         off = self.offset + index * self.element_size
-        gpu = VirtualGPU.get_current()
-        return gpu.global_memory.read(off, self.element_size)
+        return self.memory.read(off, self.element_size)
 
     def __setitem__(self, index: int, data: bytes) -> None:
-        """Store ``data`` into ``index`` on the current device's global memory."""
-
-        from .virtualgpu import VirtualGPU
+        """Store ``data`` at ``index`` inside ``self.memory``."""
 
         if len(data) != self.element_size:
             raise ValueError("data length must match element_size")
         off = self.offset + index * self.element_size
-        gpu = VirtualGPU.get_current()
-        gpu.global_memory.write(off, data)
+        self.memory.write(off, data)
 
     # ------------------------------------------------------------------
     # Representation helpers


### PR DESCRIPTION
## Summary
- remove VirtualGPU dependency from `DevicePointer` index operations
- read and write directly from the pointer's memory object

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606f9cdf5483318d4883cb167c9e2d