### PR TITLE
Add basic numeric type wrappers

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -9,6 +9,7 @@ from .warp import Warp, is_coalesced
 from .sync import syncthreads
 from .fence import threadfence_block, threadfence, threadfence_system
 from .warp_utils import shfl_sync, ballot_sync
+from .types import Half, Float32, Float64
 from .dispatch import Instruction, SIMTStack
 from .transfer import TransferEvent
 from .errors import SynchronizationError
@@ -72,5 +73,8 @@ __all__ = [
     "threadfence_block",
     "threadfence",
     "threadfence_system",
+    "Half",
+    "Float32",
+    "Float64",
 ]
 

--- a/py_virtual_gpu/types.py
+++ b/py_virtual_gpu/types.py
@@ -1,0 +1,123 @@
+"""Numeric data types used inside GPU kernels."""
+
+from __future__ import annotations
+
+import operator
+from typing import Any, Callable, Union
+
+import numpy as np
+
+
+Number = Union[int, float, np.number]
+
+
+def _unwrap(value: Any) -> Any:
+    if isinstance(value, (Half, Float32, Float64)):
+        return value.value
+    return value
+
+
+def _wrap(value: Any, dtype: np.dtype) -> "Numeric":
+    if dtype == np.float16:
+        return Half(np.float16(value))
+    if dtype == np.float32:
+        return Float32(np.float32(value))
+    if dtype == np.float64:
+        return Float64(np.float64(value))
+    raise TypeError(f"Unsupported dtype: {dtype}")
+
+
+def _promote(a: Any, b: Any) -> np.dtype:
+    return np.result_type(_unwrap(a), _unwrap(b))
+
+
+class Numeric:
+    dtype: Any
+    value: Any
+
+    def __init__(self, value: Number) -> None:
+        self.value = np.dtype(self.dtype).type(value)
+
+    # ------------------------------------------------------------------
+    def _binary_op(self, other: Any, op: Callable[[Any, Any], Any], *, reverse: bool = False) -> "Numeric":
+        dtype = _promote(self, other)
+        if reverse:
+            a_val = np.dtype(dtype).type(_unwrap(other))
+            b_val = np.dtype(dtype).type(_unwrap(self))
+        else:
+            a_val = np.dtype(dtype).type(_unwrap(self))
+            b_val = np.dtype(dtype).type(_unwrap(other))
+        result = np.dtype(dtype).type(op(a_val, b_val))
+        return _wrap(result, dtype)
+
+    # Arithmetic ---------------------------------------------------------
+    def __add__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.add)
+
+    def __radd__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.add)
+
+    def __sub__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.sub)
+
+    def __rsub__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.sub, reverse=True)
+
+    def __mul__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.mul)
+
+    def __rmul__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.mul)
+
+    def __truediv__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.truediv)
+
+    def __rtruediv__(self, other: Any) -> "Numeric":
+        return self._binary_op(other, operator.truediv, reverse=True)
+
+    # Comparison --------------------------------------------------------
+    def __eq__(self, other: Any) -> bool:  # type: ignore[override]
+        return float(self) == float(_unwrap(other))
+
+    def __lt__(self, other: Any) -> bool:
+        return float(self) < float(_unwrap(other))
+
+    def __le__(self, other: Any) -> bool:
+        return float(self) <= float(_unwrap(other))
+
+    def __gt__(self, other: Any) -> bool:
+        return float(self) > float(_unwrap(other))
+
+    def __ge__(self, other: Any) -> bool:
+        return float(self) >= float(_unwrap(other))
+
+    # Conversion --------------------------------------------------------
+    def to_float32(self) -> "Float32":
+        return Float32(np.float32(self.value))
+
+    def to_float64(self) -> "Float64":
+        return Float64(np.float64(self.value))
+
+    def __float__(self) -> float:
+        return float(self.value)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.value})"
+
+
+class Half(Numeric):
+    """Half-precision floating point number (fp16)."""
+
+    dtype = np.float16
+
+
+class Float32(Numeric):
+    """Single-precision floating point number (fp32)."""
+
+    dtype = np.float32
+
+
+class Float64(Numeric):
+    """Double-precision floating point number (fp64)."""
+
+    dtype = np.float64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Python Virtual GPU simulator"
 authors = [{name="Diego Rodrigues"}]
 readme = "README.md"
 requires-python = ">=3.10"
+dependencies = ["numpy"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 httpx
 pytest
+numpy

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import Half, Float32, Float64
+
+
+def test_basic_arithmetic_and_rounding():
+    a = Half(1.5)
+    b = Half(2.25)
+    res = a + b
+    assert isinstance(res, Half)
+    expected = np.float16(np.float16(1.5) + np.float16(2.25))
+    assert float(res) == float(expected)
+
+
+def test_promotion_to_float32():
+    a = Half(1.2)
+    b = Float32(2.3)
+    res = a * b
+    assert isinstance(res, Float32)
+    expected = np.float32(np.float16(1.2) * np.float32(2.3))
+    assert float(res) == float(expected)
+
+
+def test_promotion_to_float64():
+    a = Float32(1.5)
+    b = Float64(2.0)
+    res = b / a
+    assert isinstance(res, Float64)
+    expected = np.float64(np.float64(2.0) / np.float32(1.5))
+    assert float(res) == float(expected)
+
+
+def test_conversion_helpers():
+    a = Half(3.0)
+    assert isinstance(a.to_float32(), Float32)
+    assert isinstance(a.to_float64(), Float64)


### PR DESCRIPTION
## Summary
- create `types.py` for Half, Float32 and Float64 wrappers
- export the types in the package namespace
- test arithmetic promotions and conversions
- declare numpy dependency

## Testing
- `pytest -q`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6860708ae54c83318b211cbc38271561