### PR TITLE
Implement typed device pointers

### DIFF
--- a/py_virtual_gpu/memory.py
+++ b/py_virtual_gpu/memory.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 
-from typing import Any
+from typing import Any, Type
+
+import numpy as np
+
+from .types import Numeric
 
 from .global_memory import GlobalMemory
 from .shared_memory import SharedMemory
@@ -12,19 +16,39 @@ from .shared_memory import SharedMemory
 class DevicePointer:
     """Opaque reference to a location inside a device memory space."""
 
-    def __init__(self, offset: int, memory: GlobalMemory | SharedMemory, *, element_size: int = 4) -> None:
+    def __init__(
+        self,
+        offset: int,
+        memory: GlobalMemory | SharedMemory,
+        *,
+        element_size: int = 4,
+        dtype: Type[Numeric] | None = None,
+    ) -> None:
         self.offset = offset
         self.memory = memory
+        self.dtype = dtype
+        if dtype is not None:
+            element_size = int(np.dtype(dtype.dtype).itemsize)
         self.element_size = element_size
 
     # ------------------------------------------------------------------
     # Pointer arithmetic
     # ------------------------------------------------------------------
     def __add__(self, value: int) -> "DevicePointer":
-        return DevicePointer(self.offset + value * self.element_size, self.memory, element_size=self.element_size)
+        return DevicePointer(
+            self.offset + value * self.element_size,
+            self.memory,
+            element_size=self.element_size,
+            dtype=self.dtype,
+        )
 
     def __sub__(self, value: int) -> "DevicePointer":
-        return DevicePointer(self.offset - value * self.element_size, self.memory, element_size=self.element_size)
+        return DevicePointer(
+            self.offset - value * self.element_size,
+            self.memory,
+            element_size=self.element_size,
+            dtype=self.dtype,
+        )
 
     def __iadd__(self, value: int) -> "DevicePointer":
         self.offset += value * self.element_size
@@ -37,28 +61,39 @@ class DevicePointer:
     # ------------------------------------------------------------------
     # Memory access helpers
     # ------------------------------------------------------------------
-    def __getitem__(self, index: int) -> bytes:
+    def __getitem__(self, index: int) -> bytes | Numeric:
         """Return the element at ``index`` from ``self.memory``."""
 
         off = self.offset + index * self.element_size
-        return self.memory.read(off, self.element_size)
+        raw = self.memory.read(off, self.element_size)
+        if self.dtype is None:
+            return raw
+        value = np.frombuffer(raw, dtype=self.dtype.dtype)[0]
+        return self.dtype(value)
 
-    def __setitem__(self, index: int, data: bytes) -> None:
+    def __setitem__(self, index: int, data: bytes | Numeric) -> None:
         """Store ``data`` at ``index`` inside ``self.memory``."""
 
-        if len(data) != self.element_size:
-            raise ValueError("data length must match element_size")
+        if isinstance(data, (bytes, bytearray)):
+            if len(data) != self.element_size:
+                raise ValueError("data length must match element_size")
+            raw = bytes(data)
+        else:
+            if self.dtype is None or not isinstance(data, self.dtype):
+                raise TypeError("data must be bytes or an instance of the pointer dtype")
+            raw = np.array(data.value, dtype=self.dtype.dtype).tobytes()
         off = self.offset + index * self.element_size
-        self.memory.write(off, data)
+        self.memory.write(off, raw)
 
     # ------------------------------------------------------------------
     # Representation helpers
     # ------------------------------------------------------------------
     def __repr__(self) -> str:
         mem_name = type(self.memory).__name__
+        dtype_name = self.dtype.__name__ if self.dtype is not None else None
         return (
             f"<DevicePointer mem={mem_name} offset={self.offset} "
-            f"elem_size={self.element_size}>"
+            f"elem_size={self.element_size} dtype={dtype_name}>"
         )
 
     def __eq__(self, other: Any) -> bool:

--- a/tests/test_typed_device_pointer.py
+++ b/tests/test_typed_device_pointer.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU, Float32, Half
+
+
+def test_malloc_with_dtype_and_access():
+    gpu = VirtualGPU(0, 64)
+    ptr = gpu.malloc(2, dtype=Float32)
+    assert ptr.element_size == 4
+    ptr[0] = Float32(1.5)
+    ptr[1] = Float32(2.5)
+    assert isinstance(ptr[0], Float32)
+    assert isinstance(ptr[1], Float32)
+    assert float(ptr[0]) == 1.5
+    assert float(ptr[1]) == 2.5
+
+
+def test_malloc_type_helper_and_bytes_write():
+    gpu = VirtualGPU(0, 32)
+    ptr = gpu.malloc_type(1, Half)
+    val = np.array([3.0], dtype=np.float16).tobytes()
+    ptr[0] = val
+    assert isinstance(ptr[0], Half)
+    assert float(ptr[0]) == 3.0
+


### PR DESCRIPTION
## Summary
- extend DevicePointer to store dtype info
- let GlobalMemory.malloc and VirtualGPU.malloc take dtype
- return typed values from DevicePointer reads and accept numeric types on write
- add `VirtualGPU.malloc_type` helper
- test typed device pointer behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860731f6bac8331af66178cd1cf9fc6