### PR TITLE
Add float atomicAdd

### DIFF
--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -15,6 +15,8 @@ from .transfer import TransferEvent
 from .errors import SynchronizationError
 from .atomics import (
     atomicAdd,
+    atomicAdd_float32,
+    atomicAdd_float64,
     atomicSub,
     atomicCAS,
     atomicMax,
@@ -62,6 +64,8 @@ __all__ = [
     "KernelLaunchEvent",
     "SynchronizationError",
     "atomicAdd",
+    "atomicAdd_float32",
+    "atomicAdd_float64",
     "atomicSub",
     "atomicCAS",
     "atomicMax",

--- a/py_virtual_gpu/atomics.py
+++ b/py_virtual_gpu/atomics.py
@@ -13,6 +13,24 @@ def atomicAdd(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
     return gpu.global_mem.atomic_add(ptr.offset, value, num_bytes)
 
 
+def atomicAdd_float32(ptr: DevicePointer, value: float) -> float:
+    """Atomically add ``value`` to a 32-bit float at ``ptr``."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_add_float32(ptr.offset, value)
+
+
+def atomicAdd_float64(ptr: DevicePointer, value: float) -> float:
+    """Atomically add ``value`` to a 64-bit float at ``ptr``."""
+
+    if not isinstance(ptr, DevicePointer):
+        raise TypeError("ptr must be a DevicePointer")
+    gpu = VirtualGPU.get_current()
+    return gpu.global_mem.atomic_add_float64(ptr.offset, value)
+
+
 def atomicSub(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
     """Atomically subtract ``value`` from integer at ``ptr``."""
 
@@ -60,6 +78,8 @@ def atomicExchange(ptr: DevicePointer, value: int, num_bytes: int = 4) -> int:
 
 __all__ = [
     "atomicAdd",
+    "atomicAdd_float32",
+    "atomicAdd_float64",
     "atomicSub",
     "atomicCAS",
     "atomicMax",

--- a/tests/test_global_memory_atomic.py
+++ b/tests/test_global_memory_atomic.py
@@ -3,6 +3,7 @@ import sys
 import multiprocessing as mp
 from unittest.mock import MagicMock
 import pytest
+import struct
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -80,3 +81,21 @@ def test_atomic_wrappers_through_virtualgpu():
     swapped = atomicCAS(ptr, 3, 5)
     assert swapped is True
     assert int.from_bytes(gpu.global_mem.read(ptr.offset, 4), "little", signed=True) == 5
+
+
+def test_atomic_add_float32():
+    gm = GlobalMemory(4)
+    gm.write(0, struct.pack("<f", 1.5))
+    old = gm.atomic_add_float32(0, 2.25)
+    assert old == pytest.approx(1.5)
+    result = struct.unpack("<f", gm.read(0, 4))[0]
+    assert result == pytest.approx(3.75)
+
+
+def test_atomic_add_float64():
+    gm = GlobalMemory(8)
+    gm.write(0, struct.pack("<d", 1.5))
+    old = gm.atomic_add_float64(0, 2.25)
+    assert old == pytest.approx(1.5)
+    result = struct.unpack("<d", gm.read(0, 8))[0]
+    assert result == pytest.approx(3.75)

--- a/tests/test_shared_memory_atomic.py
+++ b/tests/test_shared_memory_atomic.py
@@ -1,7 +1,9 @@
 import os
 import sys
 import multiprocessing as mp
+import struct
 from unittest.mock import MagicMock
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -63,3 +65,21 @@ def test_atomic_methods_use_lock():
     sm.atomic_cas(0, 0, 1)
     assert mock_lock.__enter__.call_count == 4
     assert mock_lock.__exit__.call_count == 4
+
+
+def test_atomic_add_float32():
+    sm = SharedMemory(4)
+    sm.write(0, struct.pack("<f", 1.5))
+    old = sm.atomic_add_float32(0, 2.25)
+    assert old == pytest.approx(1.5)
+    result = struct.unpack("<f", sm.read(0, 4))[0]
+    assert result == pytest.approx(3.75)
+
+
+def test_atomic_add_float64():
+    sm = SharedMemory(8)
+    sm.write(0, struct.pack("<d", 1.5))
+    old = sm.atomic_add_float64(0, 2.25)
+    assert old == pytest.approx(1.5)
+    result = struct.unpack("<d", sm.read(0, 8))[0]
+    assert result == pytest.approx(3.75)


### PR DESCRIPTION
## Summary
- support atomicAdd for float32 and float64
- expose wrappers from high level API
- test float atomic operations in shared memory

## Testing
- `pytest tests/test_shared_memory_atomic.py::test_atomic_add_float32 -q`
- `pytest tests/test_shared_memory_atomic.py::test_atomic_add_float64 -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6860746f22288331a30bdfd9de609b8a