### PR TITLE
Add mixed precision example and doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ gpu.set_constant(b"values")
 - Constant memory (`64 KiB` by default) available via `gpu = VirtualGPU.get_current(); gpu.read_constant(...)` or `thread.const_mem.read(...)`.
 - `Thread.alloc_local(size)` reserves bytes in `LocalMemory` for large kernel variables.
 - Pointers returned by `malloc` are `DevicePointer` objects that support arithmetic and indexing (`ptr + n`, `ptr[i]`, etc.) similar to CUDA C++.
+- Passing a `dtype` like `Half`, `Float32` or `Float64` to `malloc` (or using `malloc_type`) yields typed pointers. Elements read from such pointers are instances of those classes and support arithmetic with automatic promotion.
 - `atomicAdd`, `atomicSub`, `atomicCAS`, `atomicMax`, `atomicMin` and `atomicExchange` operate on `DevicePointer`. The same methods are also available on `SharedMemory` and `GlobalMemory`.
 - Kernel threads run as ``multiprocessing.Process`` to bypass the GIL. Use ``ThreadBlock.execute(..., use_threads=True)`` to fall back to ``threading.Thread`` if processes are not desired. On Windows, threads are automatically used instead of processes to avoid pickling issues. On Windows, threads are automatically used instead of processes to avoid pickling issues.
 
@@ -103,12 +104,14 @@ python examples/vector_mul.py
 python examples/matrix_mul.py
 python examples/reduction_sum.py
 python examples/reduction_sum_multi.py
+python examples/mixed_precision.py
 
 # start with API support to visualize in the UI
 python examples/vector_mul.py --api
 python examples/matrix_mul.py --api
 python examples/reduction_sum.py --api
 python examples/reduction_sum_multi.py --api
+python examples/mixed_precision.py --api
 ```
 
 When ``--api`` is used the script launches the FastAPI server in the background and registers the created GPU with the global manager. You can then run the UI from the `app` directory to inspect execution:

--- a/docs/class_structure.md
+++ b/docs/class_structure.md
@@ -15,6 +15,7 @@ Implementation details of these classes and their APIs are addressed in issues *
 **Main methods**
 - `launch_kernel(func, grid_dim, block_dim, *args)`: divides the grid into blocks, schedules them on the SMs and passes the arguments to each thread.
 - `malloc(size) / free(ptr)`: interface for allocating and freeing space in `global_memory`.
+- `malloc(size, dtype)` or `malloc_type(count, dtype)` return typed pointers that handle elements of the given numeric type (`Half`, `Float32`, `Float64`).
 - `memcpy_host_to_device(...)` and `memcpy_device_to_host(...)`: simulate transfers between CPU and GPU.
 
 ## `StreamingMultiprocessor`

--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -54,6 +54,7 @@ gpu.memcpy_host_to_device(b"\x00" * 256, ptr)
 data = gpu.memcpy_device_to_host(ptr, 256)
 ```
 - Pointers returned by `malloc` are instances of `DevicePointer` that support arithmetic and indexing (`ptr + n`, `ptr[i]`, etc.), allowing syntax similar to CUDA C++. Below is a kernel that multiplies vectors using `ptr[i]`:
+- You can pass a numeric type such as `Half`, `Float32` or `Float64` to `malloc` or use `malloc_type(count, dtype)` to obtain typed pointers. Elements read from those pointers return instances of the chosen type and operations between them automatically promote to the wider dtype.
 ```python
 @kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
 def vec_mul(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ python examples/convolution_2d.py
 python examples/matrix_mul.py
 python examples/reduction_sum.py
 python examples/reduction_sum_multi.py
+python examples/mixed_precision.py
 ```
 
 Each program allocates memory on the virtual device, launches a kernel and prints
@@ -32,6 +33,7 @@ Then run an example with API support enabled:
 ```bash
 python examples/vector_mul.py --api
 python examples/matrix_mul.py --api
+python examples/mixed_precision.py --api
 ```
 
 Open ``http://localhost:5173`` to inspect the execution step by step through the

--- a/examples/mixed_precision.py
+++ b/examples/mixed_precision.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import struct
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU, Half, Float32, atomicAdd_float32
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.api.server import start_background_api
+from py_virtual_gpu.kernel import kernel
+
+
+@kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
+def dot_half_fp32(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):
+    i = threadIdx[0]
+    a = a_ptr[i]
+    b = b_ptr[i]
+    prod = a.to_float32() * b.to_float32()
+    atomicAdd_float32(out_ptr, float(prod))
+
+
+def main(with_api: bool = False) -> None:
+    if with_api:
+        api_thread, stop_api = start_background_api()
+    else:
+        api_thread = stop_api = None
+
+    gpu = VirtualGPU(num_sms=0, global_mem_size=64)
+    get_gpu_manager().add_gpu(gpu)
+    VirtualGPU.set_current(gpu)
+
+    a_vals = [1.0, 2.0, 3.0, 4.0]
+    b_vals = [5.0, 6.0, 7.0, 8.0]
+    a_bytes = np.array(a_vals, dtype=np.float16).tobytes()
+    b_bytes = np.array(b_vals, dtype=np.float16).tobytes()
+
+    a_ptr = gpu.malloc(len(a_vals), dtype=Half)
+    b_ptr = gpu.malloc(len(b_vals), dtype=Half)
+    out_ptr = gpu.malloc_type(1, Float32)
+    out_ptr[0] = Float32(0.0)
+
+    gpu.memcpy_host_to_device(a_bytes, a_ptr)
+    gpu.memcpy_host_to_device(b_bytes, b_ptr)
+
+    dot_half_fp32(a_ptr, b_ptr, out_ptr)
+    gpu.synchronize()
+
+    out = gpu.memcpy_device_to_host(out_ptr, 4)
+    result = struct.unpack("<f", out)[0]
+
+    expected = np.float32(0.0)
+    for a, b in zip(a_vals, b_vals):
+        expected += np.float32(a) * np.float32(b)
+    expected = float(expected)
+
+    print("Kernel result:", result)
+    print("Host result:", expected)
+    if abs(result - expected) < 1e-5:
+        print("Mixed precision dot product successful!")
+    else:
+        print("Mismatch detected")
+
+    if stop_api:
+        stop_api()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Mixed precision example")
+    parser.add_argument("--api", action="store_true", help="start API server while running")
+    args = parser.parse_args()
+    main(with_api=args.api)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,7 @@ import os
 import sys
 import importlib
 import ast
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -54,3 +55,10 @@ def test_vector_sum_atomic_example(capsys):
     mod.main()
     kernel, host = _parse_results(capsys.readouterr().out)
     assert kernel == host
+
+
+def test_mixed_precision_example(capsys):
+    mod = importlib.import_module("examples.mixed_precision")
+    mod.main()
+    kernel, host = _parse_results(capsys.readouterr().out)
+    assert pytest.approx(kernel, rel=1e-6) == host


### PR DESCRIPTION
## Summary
- document Half/Float32/Float64 typed pointers in README and docs
- add mixed precision example with Half input and Float32 accumulation
- list new example in documentation
- test that mixed precision example works

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686076f2a3d88331939b7e55ca33cee2