### PR TITLE
Add per-dtype latency counters and GPU presets

### DIFF
--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -28,6 +28,7 @@ class KernelLaunchRecord(BaseModel):
     grid_dim: tuple[int, int, int]
     block_dim: tuple[int, int, int]
     start_cycle: int
+    cycles: int
 
 
 class GlobalMemState(BaseModel):

--- a/py_virtual_gpu/warp.py
+++ b/py_virtual_gpu/warp.py
@@ -96,6 +96,7 @@ class Warp:
                 addr_list.append(int(addr))
             self.memory_access(addr_list, size, space)
 
+        self.sm.account_instruction(inst)
         self.pc += 1
 
         # Check if we've reached a reconvergence point recorded on the SIMT
@@ -113,6 +114,7 @@ class Warp:
         return any(self.active_mask)
     def issue_instruction(self, inst: Instruction) -> None:
         """Issue ``inst`` to the active threads (conceptual stub)."""
+        self.sm.account_instruction(inst)
         self.pc += 1
 
     def memory_access(self, addr_list: List[int], size: int, space: str = "global") -> bytes:

--- a/tests/test_kernel_log_endpoint.py
+++ b/tests/test_kernel_log_endpoint.py
@@ -36,3 +36,4 @@ def test_kernel_log_endpoint():
         assert data[0]["name"] == "dummy"
         assert data[0]["grid_dim"] == [1, 1, 1]
         assert data[0]["block_dim"] == [2, 2, 1]
+        assert "cycles" in data[0]

--- a/tests/test_virtualgpu_presets.py
+++ b/tests/test_virtualgpu_presets.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.virtualgpu import VirtualGPU
+
+
+def test_virtualgpu_presets_configure_sm_latencies():
+    gpu = VirtualGPU(num_sms=1, global_mem_size=32, preset="A100")
+    sm = gpu.sms[0]
+    assert (sm.fp16_cycles, sm.fp32_cycles, sm.fp64_cycles) == (1, 2, 4)
+
+    gpu2 = VirtualGPU(num_sms=1, global_mem_size=32, preset="RTX3080")
+    sm2 = gpu2.sms[0]
+    assert (sm2.fp16_cycles, sm2.fp32_cycles, sm2.fp64_cycles) == (2, 4, 8)


### PR DESCRIPTION
## Summary
- add fp16/fp32/fp64 latency options to StreamingMultiprocessor
- track instruction cycles during warp execution
- add presets in VirtualGPU for `RTX3080` and `A100`
- return cycle counts in kernel log API
- test latency accounting and presets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607705e8508331918a0b8957ff2f02