### PR TITLE
Add allocation tracking endpoint

### DIFF
--- a/py_virtual_gpu/api/routers/gpus.py
+++ b/py_virtual_gpu/api/routers/gpus.py
@@ -10,6 +10,7 @@ from ..schemas import (
     SMDetailed,
     MemorySlice,
     KernelLaunchRecord,
+    AllocationRecord,
 )
 
 router = APIRouter()
@@ -99,3 +100,12 @@ def kernel_log(
     """Return the kernel launch log for GPU ``id``."""
 
     return manager.get_kernel_log(id)
+
+
+@router.get("/gpus/{id}/allocations", response_model=list[AllocationRecord])
+def gpu_allocations(
+    id: int, manager: GPUManager = Depends(get_gpu_manager)
+) -> list[AllocationRecord]:
+    """Return active memory allocations for GPU ``id``."""
+
+    return manager.get_gpu_allocations(id)

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class GPUSummary(BaseModel):
@@ -29,6 +29,15 @@ class KernelLaunchRecord(BaseModel):
     block_dim: tuple[int, int, int]
     start_cycle: int
     cycles: int
+
+
+class AllocationRecord(BaseModel):
+    """Information about an active global memory allocation."""
+
+    offset: int
+    size: int
+    dtype: str | None = None
+    label: str | None = None
 
 
 class GlobalMemState(BaseModel):
@@ -65,6 +74,7 @@ class GPUState(BaseModel):
     transfer_log: list[TransferRecord]
     sms: list[SMState]
     overall_load: int
+    allocations: list[AllocationRecord] = Field(default_factory=list)
     temperature: int | None = None
     power_draw_watts: int | None = None
 

--- a/py_virtual_gpu/services/gpu_manager.py
+++ b/py_virtual_gpu/services/gpu_manager.py
@@ -53,6 +53,7 @@ class GPUManager:
             GlobalMemState,
             TransferRecord,
             GPUConfig,
+            AllocationRecord,
         )
 
         gpu = self.get_gpu(id)
@@ -80,6 +81,16 @@ class GPUManager:
             else 0,
         )
 
+        allocations = [
+            AllocationRecord(
+                offset=off,
+                size=meta[1],
+                dtype=meta[2].__name__ if meta[2] is not None else None,
+                label=meta[3],
+            )
+            for off, meta in gpu.alloc_metadata.items()
+        ]
+
         return GPUState(
             id=id,
             name=f"GPU {id}",
@@ -88,6 +99,7 @@ class GPUManager:
             transfer_log=transfer_log,
             sms=sms,
             overall_load=overall_load,
+            allocations=allocations,
         )
 
     def get_gpu_metrics(self, id: int):
@@ -181,6 +193,22 @@ class GPUManager:
 
         gpu = self.get_gpu(id)
         return [KernelLaunchRecord(**asdict(ev)) for ev in gpu.get_kernel_log()]
+
+    def get_gpu_allocations(self, id: int):
+        """Return active allocations for GPU ``id``."""
+
+        from ..api.schemas import AllocationRecord
+
+        gpu = self.get_gpu(id)
+        return [
+            AllocationRecord(
+                offset=off,
+                size=meta[1],
+                dtype=meta[2].__name__ if meta[2] is not None else None,
+                label=meta[3],
+            )
+            for off, meta in gpu.alloc_metadata.items()
+        ]
 
     def get_event_feed(self, since_cycle: int | None = None, limit: int = 100):
         """Return a global event feed aggregated from all GPUs."""

--- a/tests/test_allocations_endpoint.py
+++ b/tests/test_allocations_endpoint.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import queue
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu.api import app
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.virtualgpu import VirtualGPU
+from py_virtual_gpu.types import Float32
+
+
+def _setup_gpu():
+    manager = get_gpu_manager()
+    manager._gpus.clear()
+    gpu = VirtualGPU(num_sms=1, global_mem_size=64)
+    for sm in gpu.sms:
+        sm.block_queue = queue.Queue()
+    manager.add_gpu(gpu)
+    return gpu
+
+
+def test_allocations_endpoint_and_state():
+    gpu = _setup_gpu()
+    ptr = gpu.malloc(4, dtype=Float32, label="buf")
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/allocations")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        alloc = data[0]
+        assert alloc["offset"] == ptr.offset
+        assert alloc["size"] == 4
+        assert alloc["dtype"] == "Float32"
+        assert alloc["label"] == "buf"
+
+        state = client.get("/gpus/0/state").json()
+        assert state["allocations"][0]["offset"] == ptr.offset
+
+    gpu.free(ptr)
+    with TestClient(app) as client:
+        resp = client.get("/gpus/0/allocations")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    manager = get_gpu_manager()
+    manager._gpus.clear()


### PR DESCRIPTION
## Summary
- track allocation metadata in `VirtualGPU`
- expose allocations through `GPUManager` and API endpoint
- extend `GPUState` schema with allocation info
- add unit tests for `/gpus/{id}/allocations`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68608a4a1bec8331b2d5fb5e75181c61