### PR TITLE
Add allocation list viewer

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -4,6 +4,7 @@ import { GPUState, SimulatorEvent, GpuSummary, BackendData, MemorySlice } from '
 import { fetchBackendData, fetchGpuState, fetchGlobalMemorySlice, fetchConstantMemorySlice } from './services/gpuSimulatorService';
 import { IconChip, IconMemory, IconActivity, IconInfo, IconChevronDown, IconChevronUp, Tooltip, MemoryUsageDisplay, SmCard, GpuOverviewCard, TransfersDisplay, EventLog, IconGpu, IconLink, StatDisplay } from './components/components';
 import { MemoryViewer } from './components/MemoryViewer';
+import { AllocationList } from './components/AllocationList';
 import { KernelLogView } from './components/KernelLogView';
 
 
@@ -231,6 +232,7 @@ export const GpuDetailView: React.FC<{ gpu: GPUState }> = ({ gpu }) => {
             </div>
             {loading && <p className="text-xs text-gray-400">Loading...</p>}
             {slice && <MemoryViewer slice={slice} />}
+            <AllocationList gpuId={gpu.id} onSelect={setSlice} />
             <button
               onClick={() => setShowKernelLog((v) => !v)}
               className="mt-4 px-2 py-1 bg-gray-700 rounded text-xs"

--- a/app/src/__tests__/AllocationList.test.tsx
+++ b/app/src/__tests__/AllocationList.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import { AllocationList } from '../components/AllocationList';
+import { AllocationRecord, MemorySlice } from '../types/types';
+import * as service from '../services/gpuSimulatorService';
+
+vi.mock('../services/gpuSimulatorService', () => ({
+  fetchAllocations: vi.fn(),
+  fetchGlobalMemorySlice: vi.fn(),
+}));
+
+const mockFetchAllocs = service.fetchAllocations as unknown as ReturnType<typeof vi.fn>;
+const mockFetchSlice = service.fetchGlobalMemorySlice as unknown as ReturnType<typeof vi.fn>;
+
+const allocs: AllocationRecord[] = [
+  { offset: 0, size: 4, dtype: 'Float32', label: 'buf' },
+];
+
+const slice: MemorySlice = { offset: 0, size: 4, data: Buffer.from('0000', 'hex').toString('hex') };
+
+describe('AllocationList', () => {
+  it('lists allocations and fetches slice on click', async () => {
+    mockFetchAllocs.mockResolvedValue(allocs);
+    mockFetchSlice.mockResolvedValue(slice);
+    const handleSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<AllocationList gpuId="0" onSelect={handleSelect} />);
+
+    expect(await screen.findByText('buf')).toBeInTheDocument();
+
+    await user.click(screen.getByText('buf'));
+    expect(mockFetchSlice).toHaveBeenCalledWith('0', 0, 4, 'float32');
+    expect(handleSelect).toHaveBeenCalledWith(slice);
+  });
+});

--- a/app/src/__tests__/DashboardLayout.test.tsx
+++ b/app/src/__tests__/DashboardLayout.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { vi } from 'vitest';
 import { DashboardLayout } from '../App';
 import { GPUState, GpuSummary } from '../types/types';
+import * as service from '../services/gpuSimulatorService';
+
+vi.mock('../services/gpuSimulatorService', () => ({
+  fetchAllocations: vi.fn(),
+}));
+
+const mockFetchAllocs = service.fetchAllocations as unknown as ReturnType<typeof vi.fn>;
 
 const gpu: GPUState = {
   id: '0',
@@ -29,6 +37,9 @@ const gpu2: GPUState = { ...gpu, id: '1', name: 'GPU 1' };
 const summary2: GpuSummary = { ...summary, id: '1', name: 'GPU 1' };
 
 describe('DashboardLayout view switching', () => {
+  beforeEach(() => {
+    mockFetchAllocs.mockResolvedValue([]);
+  });
   it('shows cluster view when currentView is cluster', () => {
     render(
       <DashboardLayout

--- a/app/src/components/AllocationList.tsx
+++ b/app/src/components/AllocationList.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { AllocationRecord, MemorySlice } from '../types/types';
+import { fetchAllocations, fetchGlobalMemorySlice } from '../services/gpuSimulatorService';
+
+interface AllocationListProps {
+  gpuId: string;
+  onSelect: (slice: MemorySlice) => void;
+}
+
+export const AllocationList: React.FC<AllocationListProps> = ({ gpuId, onSelect }) => {
+  const [allocations, setAllocations] = useState<AllocationRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    fetchAllocations(gpuId)
+      .then((allocs) => {
+        if (mounted) setAllocations(allocs);
+      })
+      .catch((err) => console.error('Failed to fetch allocations', err))
+      .finally(() => setLoading(false));
+    return () => {
+      mounted = false;
+    };
+  }, [gpuId]);
+
+  const dtypeMap: Record<string, 'half' | 'float32' | 'float64' | undefined> = {
+    Half: 'half',
+    Float32: 'float32',
+    Float64: 'float64',
+  };
+
+  const handleClick = async (alloc: AllocationRecord) => {
+    try {
+      const dtype = alloc.dtype ? dtypeMap[alloc.dtype] : undefined;
+      const slice = await fetchGlobalMemorySlice(gpuId, alloc.offset, alloc.size, dtype);
+      onSelect(slice);
+    } catch (err) {
+      console.error('Failed to fetch memory slice', err);
+    }
+  };
+
+  if (loading) {
+    return <p className="text-xs text-gray-400">Loading allocations...</p>;
+  }
+
+  if (allocations.length === 0) {
+    return <p className="text-xs text-gray-400">No active allocations.</p>;
+  }
+
+  return (
+    <table className="text-xs w-full mt-2">
+      <thead>
+        <tr className="text-left">
+          <th className="pr-2">Label</th>
+          <th className="pr-2">Offset</th>
+          <th className="pr-2">Size</th>
+          <th>Dtype</th>
+        </tr>
+      </thead>
+      <tbody>
+        {allocations.map((a, idx) => (
+          <tr
+            key={idx}
+            className="odd:bg-gray-800 cursor-pointer hover:bg-gray-700"
+            onClick={() => handleClick(a)}
+          >
+            <td className="font-mono pr-2">{a.label ?? '-'}</td>
+            <td className="pr-2">{a.offset}</td>
+            <td className="pr-2">{a.size}</td>
+            <td>{a.dtype ?? '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/app/src/services/gpuSimulatorService.ts
+++ b/app/src/services/gpuSimulatorService.ts
@@ -9,6 +9,7 @@ import {
   SMDetailed,
   MemorySlice,
   KernelLaunchRecord,
+  AllocationRecord,
 } from '../types/types';
 
 const API_BASE = (import.meta as any).env?.VITE_API_BASE_URL || 'http://localhost:8000';
@@ -145,6 +146,12 @@ export const fetchConstantMemorySlice = async (
   return fetchJSON<MemorySlice>(
     `${API_BASE}/gpus/${gpuId}/constant_mem?offset=${offset}&size=${size}${dtypeParam}`,
   );
+};
+
+export const fetchAllocations = async (
+  gpuId: string,
+): Promise<AllocationRecord[]> => {
+  return fetchJSON<AllocationRecord[]>(`${API_BASE}/gpus/${gpuId}/allocations`);
 };
 
 export const fetchKernelLog = async (

--- a/app/src/types/types.ts
+++ b/app/src/types/types.ts
@@ -77,6 +77,13 @@ export interface MemorySlice {
   values?: number[];
 }
 
+export interface AllocationRecord {
+  offset: number;
+  size: number;
+  dtype?: string | null;
+  label?: string | null;
+}
+
 export interface SMDetailed {
   id: number;
   blocks: BlockSummary[];


### PR DESCRIPTION
## Summary
- add `AllocationRecord` type for frontend
- fetch GPU allocations from the API
- implement `AllocationList` component for interactive slice viewing
- integrate allocation list into the GPU detail view
- test allocation listing and selection behaviour

## Testing
- `pytest tests/test_allocations_endpoint.py::test_allocations_endpoint_and_state -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68608ec691c083319ae84c20ed7a6a08