### PR TITLE
Expose dtype in memory slice responses

### DIFF
--- a/py_virtual_gpu/api/routers/gpus.py
+++ b/py_virtual_gpu/api/routers/gpus.py
@@ -90,7 +90,13 @@ def global_mem_slice(
         arr = np.frombuffer(data, dtype=cls.dtype)
         values = [float(cls(v)) for v in arr]
 
-    return MemorySlice(offset=offset, size=len(data), data=data.hex(), values=values)
+    return MemorySlice(
+        offset=offset,
+        size=len(data),
+        dtype=dtype,
+        data=data.hex(),
+        values=values,
+    )
 
 
 @router.get("/gpus/{id}/constant_mem", response_model=MemorySlice)
@@ -122,7 +128,13 @@ def constant_mem_slice(
         arr = np.frombuffer(data, dtype=cls.dtype)
         values = [float(cls(v)) for v in arr]
 
-    return MemorySlice(offset=offset, size=len(data), data=data.hex(), values=values)
+    return MemorySlice(
+        offset=offset,
+        size=len(data),
+        dtype=dtype,
+        data=data.hex(),
+        values=values,
+    )
 
 
 @router.get("/gpus/{id}/kernel_log", response_model=list[KernelLaunchRecord])

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -139,6 +139,7 @@ class MemorySlice(BaseModel):
 
     offset: int
     size: int
+    dtype: str | None = None
     data: str
     values: list[float] | None = None
 

--- a/py_virtual_gpu/memory.py
+++ b/py_virtual_gpu/memory.py
@@ -90,7 +90,9 @@ class DevicePointer:
     # ------------------------------------------------------------------
     def __repr__(self) -> str:
         mem_name = type(self.memory).__name__
-        dtype_name = self.dtype.__name__ if self.dtype is not None else None
+        dtype_name = None
+        if self.dtype is not None:
+            dtype_name = getattr(self.dtype, "__name__", str(self.dtype))
         return (
             f"<DevicePointer mem={mem_name} offset={self.offset} "
             f"elem_size={self.element_size} dtype={dtype_name}>"

--- a/tests/test_memory_slice_endpoints.py
+++ b/tests/test_memory_slice_endpoints.py
@@ -34,6 +34,7 @@ def test_global_memory_slice_endpoint():
         assert bytes.fromhex(data["data"]) == b"abcdefgh"
         assert data["offset"] == ptr.offset
         assert data["size"] == 8
+        assert data["dtype"] is None
 
 
 def test_constant_memory_slice_endpoint():
@@ -47,6 +48,7 @@ def test_constant_memory_slice_endpoint():
         assert bytes.fromhex(data["data"]) == b"xyz"
         assert data["offset"] == 0
         assert data["size"] == 3
+        assert data["dtype"] is None
 
 
 def test_global_mem_slice_decoding_float32():
@@ -61,6 +63,7 @@ def test_global_mem_slice_decoding_float32():
         assert resp.status_code == 200
         data = resp.json()
         assert data["values"] == [1.5, -2.0]
+        assert data["dtype"] == "float32"
 
 
 def test_constant_mem_slice_decoding_half():
@@ -73,3 +76,4 @@ def test_constant_mem_slice_decoding_half():
         assert resp.status_code == 200
         data = resp.json()
         assert data["values"] == [float(Half(v)) for v in arr]
+        assert data["dtype"] == "half"


### PR DESCRIPTION
## Summary
- refine DevicePointer repr to show dtype name when available
- include dtype field in MemorySlice schema
- return dtype in global/constant memory endpoints
- test that endpoints return the correct dtype

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686091fa2f388331b8e303a1547c3961