### PR TITLE
Add labeled allocations example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ gpu.set_constant(b"values")
 - `Thread.alloc_local(size)` reserves bytes in `LocalMemory` for large kernel variables.
 - Pointers returned by `malloc` are `DevicePointer` objects that support arithmetic and indexing (`ptr + n`, `ptr[i]`, etc.) similar to CUDA C++.
 - Passing a `dtype` like `Half`, `Float32` or `Float64` to `malloc` (or using `malloc_type`) yields typed pointers. Elements read from such pointers are instances of those classes and support arithmetic with automatic promotion.
+- A `label` string can be supplied to `malloc` to name the allocation. When the API server is running these labels appear in the dashboard's allocations table so buffers are easier to identify.
 - `atomicAdd`, `atomicSub`, `atomicCAS`, `atomicMax`, `atomicMin` and `atomicExchange` operate on `DevicePointer`. The same methods are also available on `SharedMemory` and `GlobalMemory`.
 - Kernel threads run as ``multiprocessing.Process`` to bypass the GIL. Use ``ThreadBlock.execute(..., use_threads=True)`` to fall back to ``threading.Thread`` if processes are not desired. On Windows, threads are automatically used instead of processes to avoid pickling issues. On Windows, threads are automatically used instead of processes to avoid pickling issues.
 
@@ -83,6 +84,16 @@ gpu.set_constant(b"abc")
 print(gpu.read_constant(0, 3))
 ```
 
+### Allocation Labels
+
+Provide a `label` when calling `malloc` to make buffers easier to spot in the dashboard:
+
+```python
+weights = gpu.malloc(16, dtype=Float32, label="weights")
+```
+
+The GPU detail page lists all active allocations and shows their labels next to the offsets.
+
 ## API
 
 To start the API run:
@@ -105,6 +116,7 @@ python examples/matrix_mul.py
 python examples/reduction_sum.py
 python examples/reduction_sum_multi.py
 python examples/mixed_precision.py
+python examples/inspect_allocations.py
 
 # start with API support to visualize in the UI
 python examples/vector_mul.py --api
@@ -112,9 +124,10 @@ python examples/matrix_mul.py --api
 python examples/reduction_sum.py --api
 python examples/reduction_sum_multi.py --api
 python examples/mixed_precision.py --api
+python examples/inspect_allocations.py --dashboard
 ```
 
-When ``--api`` is used the script launches the FastAPI server in the background and registers the created GPU with the global manager. You can then run the UI from the `app` directory to inspect execution:
+When ``--api`` (or ``--dashboard`` for the allocation example) is used the script launches the FastAPI server in the background and registers the created GPU with the global manager. You can then run the UI from the `app` directory to inspect execution:
 
 ```bash
 cd app && npm install && npm run dev

--- a/docs/components_and_execution.md
+++ b/docs/components_and_execution.md
@@ -55,6 +55,7 @@ data = gpu.memcpy_device_to_host(ptr, 256)
 ```
 - Pointers returned by `malloc` are instances of `DevicePointer` that support arithmetic and indexing (`ptr + n`, `ptr[i]`, etc.), allowing syntax similar to CUDA C++. Below is a kernel that multiplies vectors using `ptr[i]`:
 - You can pass a numeric type such as `Half`, `Float32` or `Float64` to `malloc` or use `malloc_type(count, dtype)` to obtain typed pointers. Elements read from those pointers return instances of the chosen type and operations between them automatically promote to the wider dtype.
+- `malloc` also accepts a `label` string so allocations can be identified in API responses and in the dashboard.
 ```python
 @kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
 def vec_mul(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ python examples/matrix_mul.py
 python examples/reduction_sum.py
 python examples/reduction_sum_multi.py
 python examples/mixed_precision.py
+python examples/inspect_allocations.py
 ```
 
 Each program allocates memory on the virtual device, launches a kernel and prints
@@ -21,8 +22,9 @@ whether the result computed on the device matches the host computation.
 ### Visualizing via API and UI
 
 All examples accept the ``--api`` flag to start the FastAPI server while they
-run. When the server is active you can launch the dashboard UI from the
-``app`` directory:
+run. The ``inspect_allocations.py`` script also provides ``--dashboard`` to
+launch the UI automatically. When the server is active you can manually start
+the dashboard from the ``app`` directory:
 
 ```bash
 cd app && npm install && npm run dev
@@ -34,6 +36,7 @@ Then run an example with API support enabled:
 python examples/vector_mul.py --api
 python examples/matrix_mul.py --api
 python examples/mixed_precision.py --api
+python examples/inspect_allocations.py --dashboard
 ```
 
 Open ``http://localhost:5173`` to inspect the execution step by step through the

--- a/examples/inspect_allocations.py
+++ b/examples/inspect_allocations.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from py_virtual_gpu import VirtualGPU, Float32
+from py_virtual_gpu.kernel import kernel
+from py_virtual_gpu.services import get_gpu_manager
+from py_virtual_gpu.api.server import start_background_dashboard
+
+
+@kernel(grid_dim=(1, 1, 1), block_dim=(4, 1, 1))
+def add_vec(threadIdx, blockIdx, blockDim, gridDim, a_ptr, b_ptr, out_ptr):
+    i = threadIdx[0]
+    out_ptr[i] = a_ptr[i] + b_ptr[i]
+
+
+def main(with_dashboard: bool = False) -> None:
+    if with_dashboard:
+        api_thread, ui_proc, stop = start_background_dashboard()
+    else:
+        api_thread = ui_proc = stop = None
+
+    gpu = VirtualGPU(num_sms=0, global_mem_size=64)
+    get_gpu_manager().add_gpu(gpu)
+    VirtualGPU.set_current(gpu)
+
+    a_vals = [1.0, 2.0, 3.0, 4.0]
+    b_vals = [5.0, 6.0, 7.0, 8.0]
+
+    a_ptr = gpu.malloc(len(a_vals), dtype=Float32, label="A")
+    b_ptr = gpu.malloc(len(b_vals), dtype=Float32, label="B")
+    out_ptr = gpu.malloc(len(a_vals), dtype=Float32, label="OUT")
+
+    for i, v in enumerate(a_vals):
+        a_ptr[i] = Float32(v)
+    for i, v in enumerate(b_vals):
+        b_ptr[i] = Float32(v)
+
+    add_vec(a_ptr, b_ptr, out_ptr)
+    gpu.synchronize()
+
+    result = [float(out_ptr[i]) for i in range(len(a_vals))]
+    expected = [a_vals[i] + b_vals[i] for i in range(len(a_vals))]
+
+    print("Kernel result:", result)
+    print("Host result:", expected)
+
+    if stop:
+        stop()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Inspect allocations example")
+    parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="launch API server and dashboard while running",
+    )
+    args = parser.parse_args()
+    main(with_dashboard=args.dashboard)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -62,3 +62,10 @@ def test_mixed_precision_example(capsys):
     mod.main()
     kernel, host = _parse_results(capsys.readouterr().out)
     assert pytest.approx(kernel, rel=1e-6) == host
+
+
+def test_inspect_allocations_example(capsys):
+    mod = importlib.import_module("examples.inspect_allocations")
+    mod.main()
+    kernel, host = _parse_results(capsys.readouterr().out)
+    assert kernel == host


### PR DESCRIPTION
## Summary
- document labeling allocations in README
- add inspect_allocations.py example and reference it in docs
- update components docs with `label` parameter
- ensure new example runs in the test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686092051ef0833195731d5ed851c5a0