### PR TITLE
Improve log timestamps and UI

### DIFF
--- a/app/src/__tests__/EventLog.test.tsx
+++ b/app/src/__tests__/EventLog.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { EventLog } from '../components/components';
+import { SimulatorEvent } from '../types/types';
+
+const events: SimulatorEvent[] = [
+  {
+    id: '1',
+    timestamp: '2025-06-29T12:00:00Z',
+    type: 'KERNEL_LAUNCH',
+    message: 'Kernel A launched',
+    gpuId: '0'
+  }
+];
+
+describe('EventLog', () => {
+  it('renders event information', () => {
+    render(<EventLog events={events} />);
+    const ts = new Date(events[0].timestamp).toLocaleString();
+    expect(screen.getByText(events[0].message)).toBeInTheDocument();
+    expect(screen.getByText(ts)).toBeInTheDocument();
+    expect(screen.getByText('KERNEL_LAUNCH')).toBeInTheDocument();
+  });
+});

--- a/app/src/__tests__/KernelLogView.test.tsx
+++ b/app/src/__tests__/KernelLogView.test.tsx
@@ -12,7 +12,13 @@ vi.mock('../services/gpuSimulatorService', () => ({
 const mockFetch = service.fetchKernelLog as unknown as ReturnType<typeof vi.fn>;
 
 const log: KernelLaunchRecord[] = [
-  { name: 'dummy', grid_dim: [1, 1, 1], block_dim: [2, 2, 1], start_cycle: 5 },
+  {
+    name: 'dummy',
+    grid_dim: [1, 1, 1],
+    block_dim: [2, 2, 1],
+    start_cycle: 5,
+    timestamp: '2025-06-29T12:00:00Z',
+  },
 ];
 
 describe('KernelLogView', () => {
@@ -23,5 +29,7 @@ describe('KernelLogView', () => {
     expect(screen.getByText('1x1x1')).toBeInTheDocument();
     expect(screen.getByText('2x2x1')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
+    const ts = new Date(log[0].timestamp).toLocaleString();
+    expect(screen.getByText(ts)).toBeInTheDocument();
   });
 });

--- a/app/src/components/KernelLogView.tsx
+++ b/app/src/components/KernelLogView.tsx
@@ -28,7 +28,8 @@ export const KernelLogView: React.FC<{ gpuId: string }> = ({ gpuId }) => {
           <th className="pr-4">Name</th>
           <th className="pr-4">Grid</th>
           <th className="pr-4">Block</th>
-          <th>Start Cycle</th>
+          <th className="pr-4">Start Cycle</th>
+          <th>Timestamp</th>
         </tr>
       </thead>
       <tbody>
@@ -37,7 +38,8 @@ export const KernelLogView: React.FC<{ gpuId: string }> = ({ gpuId }) => {
             <td className="font-mono pr-4">{k.name}</td>
             <td className="pr-4">{k.grid_dim.join('x')}</td>
             <td className="pr-4">{k.block_dim.join('x')}</td>
-            <td>{k.start_cycle}</td>
+            <td className="pr-4">{k.start_cycle}</td>
+            <td>{new Date(k.timestamp).toLocaleString()}</td>
           </tr>
         ))}
       </tbody>

--- a/app/src/components/components.tsx
+++ b/app/src/components/components.tsx
@@ -308,7 +308,7 @@ export const EventLog: React.FC<EventLogProps> = ({ events }) => {
         {events.map(event => (
           <div key={event.id} className="mb-2.5 pb-2.5 border-b border-gray-700 last:border-b-0 last:pb-0 last:mb-0">
             <div className="flex justify-between text-xs text-gray-500 mb-0.5">
-              <span>{new Date(event.timestamp).toLocaleTimeString()}</span>
+              <span>{new Date(event.timestamp).toLocaleString()}</span>
               <span className={getEventTypeColor(event.type)}>{event.type}</span>
             </div>
             <p className="text-sm text-gray-200">{event.message}</p>

--- a/py_virtual_gpu/api/schemas.py
+++ b/py_virtual_gpu/api/schemas.py
@@ -19,6 +19,7 @@ class TransferRecord(BaseModel):
     size: int
     start_cycle: int
     end_cycle: int
+    timestamp: str
 
 
 class KernelLaunchRecord(BaseModel):
@@ -29,6 +30,7 @@ class KernelLaunchRecord(BaseModel):
     block_dim: tuple[int, int, int]
     start_cycle: int
     cycles: int
+    timestamp: str
 
 
 class AllocationRecord(BaseModel):
@@ -112,6 +114,7 @@ class DivergenceRecord(BaseModel):
     pc: int
     mask_before: list[bool]
     mask_after: list[bool]
+    timestamp: str
 
 
 class BlockEventRecord(BaseModel):
@@ -121,6 +124,7 @@ class BlockEventRecord(BaseModel):
     sm_id: int
     phase: str
     start_cycle: int
+    timestamp: str
 
 
 class SMDetailed(BaseModel):

--- a/py_virtual_gpu/services/gpu_manager.py
+++ b/py_virtual_gpu/services/gpu_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import List
 from dataclasses import asdict
-from datetime import datetime
 from uuid import uuid4
 
 from ..virtualgpu import VirtualGPU
@@ -221,7 +220,10 @@ class GPUManager:
                     item["gpu_id"] = gpu_id
                     item["type"] = "kernel"
                     item["id"] = str(uuid4())
-                    item["timestamp"] = datetime.utcnow().isoformat()
+                    item["timestamp"] = ev.timestamp
+                    item["message"] = (
+                        f"Kernel '{ev.name}' launched grid {ev.grid_dim} block {ev.block_dim}"
+                    )
                     events.append(item)
             for ev in gpu.get_transfer_log():
                 if since_cycle is None or ev.start_cycle >= since_cycle:
@@ -229,7 +231,8 @@ class GPUManager:
                     item["gpu_id"] = gpu_id
                     item["type"] = "transfer"
                     item["id"] = str(uuid4())
-                    item["timestamp"] = datetime.utcnow().isoformat()
+                    item["timestamp"] = ev.timestamp
+                    item["message"] = f"{ev.direction} transfer of {ev.size} bytes"
                     events.append(item)
             for sm in gpu.sms:
                 for ev in sm.get_divergence_log():
@@ -238,7 +241,10 @@ class GPUManager:
                         item["gpu_id"] = gpu_id
                         item["type"] = "divergence"
                         item["id"] = str(uuid4())
-                        item["timestamp"] = datetime.utcnow().isoformat()
+                        item["timestamp"] = ev.timestamp
+                        item["message"] = (
+                            f"Warp {ev.warp_id} divergence at PC {ev.pc}"
+                        )
                         events.append(item)
                 for ev in sm.get_block_event_log():
                     if since_cycle is None or ev.start_cycle >= since_cycle:
@@ -246,7 +252,10 @@ class GPUManager:
                         item["gpu_id"] = gpu_id
                         item["type"] = f"BLOCK_{ev.phase.upper()}"
                         item["id"] = str(uuid4())
-                        item["timestamp"] = datetime.utcnow().isoformat()
+                        item["timestamp"] = ev.timestamp
+                        item["message"] = (
+                            f"Block {ev.block_idx} {ev.phase} on SM {ev.sm_id}"
+                        )
                         events.append(item)
 
         events.sort(key=lambda e: e.get("start_cycle", 0))

--- a/py_virtual_gpu/streaming_multiprocessor.py
+++ b/py_virtual_gpu/streaming_multiprocessor.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from queue import Queue
 from typing import List, Dict, Optional, TYPE_CHECKING
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 
 from .shared_memory import SharedMemory  # type: ignore
 from .thread_block import ThreadBlock  # type: ignore
@@ -21,6 +22,7 @@ class BlockEvent:
     sm_id: int
     phase: str  # "start" or "end"
     start_cycle: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
 if TYPE_CHECKING:  # pragma: no cover - type hinting
     from .virtualgpu import VirtualGPU
@@ -35,6 +37,7 @@ class DivergenceEvent:
     mask_before: List[bool]
     mask_after: List[bool]
     start_cycle: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
 
 class StreamingMultiprocessor:

--- a/py_virtual_gpu/transfer.py
+++ b/py_virtual_gpu/transfer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 
 __all__ = ["TransferEvent"]
 
@@ -12,3 +13,4 @@ class TransferEvent:
     size: int
     start_cycle: int
     end_cycle: int
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())

--- a/py_virtual_gpu/virtualgpu.py
+++ b/py_virtual_gpu/virtualgpu.py
@@ -14,7 +14,8 @@ from .thread_block import ThreadBlock  # type: ignore  # noqa: F401
 from .memory_hierarchy import HostMemory, ConstantMemory
 from .transfer import TransferEvent
 from .types import Numeric
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from datetime import datetime
 
 
 def _execute_block_worker(
@@ -34,6 +35,7 @@ class KernelLaunchEvent:
     block_dim: Tuple[int, int, int]
     start_cycle: int
     cycles: int = 0
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
 
 
 class VirtualGPU:

--- a/tests/test_events_endpoint.py
+++ b/tests/test_events_endpoint.py
@@ -44,3 +44,6 @@ def test_events_endpoint_returns_all():
         assert data == sorted(data, key=lambda e: e["start_cycle"])
         types = {ev["type"] for ev in data}
         assert {"kernel", "transfer", "divergence", "BLOCK_START", "BLOCK_END"} <= types
+        for ev in data:
+            assert "timestamp" in ev
+            assert "message" in ev

--- a/tests/test_kernel_log_endpoint.py
+++ b/tests/test_kernel_log_endpoint.py
@@ -37,3 +37,4 @@ def test_kernel_log_endpoint():
         assert data[0]["grid_dim"] == [1, 1, 1]
         assert data[0]["block_dim"] == [2, 2, 1]
         assert "cycles" in data[0]
+        assert "timestamp" in data[0]

--- a/tests/test_sm_detail_endpoint.py
+++ b/tests/test_sm_detail_endpoint.py
@@ -42,3 +42,5 @@ def test_sm_detail_divergence_log_size():
         assert data["counters"]["warp_divergences"] == len(data["divergence_log"])
         assert "block_event_log" in data
         assert "barrier_wait_ms" in data["counters"]
+        assert all("timestamp" in d for d in data["divergence_log"])
+        assert all("timestamp" in b for b in data["block_event_log"])


### PR DESCRIPTION
## Summary
- include timestamp field in more event records and use it in event feed
- enhance EventLog and KernelLogView UI to show readable timestamps
- add comprehensive tests for timestamp presence in API responses and React components

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615b3eb91c83318c836a8ec10b7d2d