### PR TITLE
Add sqrt_numeric helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ gpu.set_constant(b"values")
 - `Thread.alloc_local(size)` reserves bytes in `LocalMemory` for large kernel variables.
 - Pointers returned by `malloc` are `DevicePointer` objects that support arithmetic and indexing (`ptr + n`, `ptr[i]`, etc.) similar to CUDA C++.
 - Passing a `dtype` like `Half`, `Float32` or `Float64` to `malloc` (or using `malloc_type`) yields typed pointers. Elements read from such pointers are instances of those classes and support arithmetic with automatic promotion.
+- Helper math functions `sqrt_numeric`, `sin_numeric`, `cos_numeric`, `exp_numeric` and `log_numeric` operate on these typed numbers while preserving their dtype.
 - A `label` string can be supplied to `malloc` to name the allocation. When the API server is running these labels appear in the dashboard's allocations table so buffers are easier to identify.
 - `atomicAdd`, `atomicSub`, `atomicCAS`, `atomicMax`, `atomicMin` and `atomicExchange` operate on `DevicePointer`. The same methods are also available on `SharedMemory` and `GlobalMemory`.
 - Kernel threads run as ``multiprocessing.Process`` to bypass the GIL. Use ``ThreadBlock.execute(..., use_threads=True)`` to fall back to ``threading.Thread`` if processes are not desired. On Windows, threads are automatically used instead of processes to avoid pickling issues. On Windows, threads are automatically used instead of processes to avoid pickling issues.

--- a/py_virtual_gpu/__init__.py
+++ b/py_virtual_gpu/__init__.py
@@ -9,7 +9,16 @@ from .warp import Warp, is_coalesced
 from .sync import syncthreads
 from .fence import threadfence_block, threadfence, threadfence_system
 from .warp_utils import shfl_sync, ballot_sync
-from .types import Half, Float32, Float64
+from .types import (
+    Half,
+    Float32,
+    Float64,
+    sqrt_numeric,
+    sin_numeric,
+    cos_numeric,
+    exp_numeric,
+    log_numeric,
+)
 from .dispatch import Instruction, SIMTStack
 from .transfer import TransferEvent
 from .errors import SynchronizationError
@@ -80,5 +89,10 @@ __all__ = [
     "Half",
     "Float32",
     "Float64",
+    "sqrt_numeric",
+    "sin_numeric",
+    "cos_numeric",
+    "exp_numeric",
+    "log_numeric",
 ]
 

--- a/py_virtual_gpu/types.py
+++ b/py_virtual_gpu/types.py
@@ -121,3 +121,50 @@ class Float64(Numeric):
     """Double-precision floating point number (fp64)."""
 
     dtype = np.float64
+
+
+def sqrt_numeric(value: Numeric) -> Numeric:
+    """Return the square root of ``value`` preserving its dtype."""
+
+    result = np.sqrt(_unwrap(value))
+    return _wrap(result, np.dtype(value.dtype))
+
+
+def sin_numeric(value: Numeric) -> Numeric:
+    """Return ``sin(value)`` preserving its dtype."""
+
+    result = np.sin(_unwrap(value))
+    return _wrap(result, np.dtype(value.dtype))
+
+
+def cos_numeric(value: Numeric) -> Numeric:
+    """Return ``cos(value)`` preserving its dtype."""
+
+    result = np.cos(_unwrap(value))
+    return _wrap(result, np.dtype(value.dtype))
+
+
+def exp_numeric(value: Numeric) -> Numeric:
+    """Return ``exp(value)`` preserving its dtype."""
+
+    result = np.exp(_unwrap(value))
+    return _wrap(result, np.dtype(value.dtype))
+
+
+def log_numeric(value: Numeric) -> Numeric:
+    """Return ``log(value)`` preserving its dtype."""
+
+    result = np.log(_unwrap(value))
+    return _wrap(result, np.dtype(value.dtype))
+
+
+__all__ = [
+    "Half",
+    "Float32",
+    "Float64",
+    "sqrt_numeric",
+    "sin_numeric",
+    "cos_numeric",
+    "exp_numeric",
+    "log_numeric",
+]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,16 @@ import numpy as np
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from py_virtual_gpu import Half, Float32, Float64
+from py_virtual_gpu import (
+    Half,
+    Float32,
+    Float64,
+    sqrt_numeric,
+    sin_numeric,
+    cos_numeric,
+    exp_numeric,
+    log_numeric,
+)
 
 
 def test_basic_arithmetic_and_rounding():
@@ -38,3 +47,30 @@ def test_conversion_helpers():
     a = Half(3.0)
     assert isinstance(a.to_float32(), Float32)
     assert isinstance(a.to_float64(), Float64)
+
+
+def test_sqrt_numeric():
+    val = Float32(4.0)
+    res = sqrt_numeric(val)
+    assert isinstance(res, Float32)
+    assert float(res) == float(np.sqrt(np.float32(4.0)))
+
+
+def test_trigonometric_and_exp_log():
+    val = Float32(np.pi / 2)
+    sin_res = sin_numeric(val)
+    assert isinstance(sin_res, Float32)
+    assert np.isclose(float(sin_res), 1.0)
+
+    cos_res = cos_numeric(Float32(0.0))
+    assert isinstance(cos_res, Float32)
+    assert np.isclose(float(cos_res), 1.0)
+
+    exp_res = exp_numeric(Float32(0.0))
+    assert isinstance(exp_res, Float32)
+    assert np.isclose(float(exp_res), 1.0)
+
+    log_res = log_numeric(Float32(1.0))
+    assert isinstance(log_res, Float32)
+    assert np.isclose(float(log_res), 0.0)
+


### PR DESCRIPTION
## Summary
- add common math helpers in `types.py`
- expose new math helpers from package
- document numeric helper functions in README
- test sqrt_numeric and other math helpers preserve dtype

## Testing
- `pip install fastapi numpy httpx uvicorn -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e6d487c4833185604999e04173da