### PR TITLE
Fix Adam example test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -80,7 +80,8 @@ def test_inspect_allocations_example(capsys):
 
 
 def test_adam_basic_example(capsys):
-    mod = importlib.import_module("examples.adam_basic")
-    mod.main()
+    from examples import adam_basic
+
+    adam_basic.main()
     kernel, host = _parse_results(capsys.readouterr().out)
-    assert pytest.approx(kernel, rel=1e-6) == host
+    assert kernel == pytest.approx(host)


### PR DESCRIPTION
## Summary
- tweak Adam example test to import the module directly
- check kernel vs host results with pytest.approx

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627432f068833195b15aee5d5544e4