### PR TITLE
Recreate pool after synchronize

### DIFF
--- a/py_virtual_gpu/virtualgpu.py
+++ b/py_virtual_gpu/virtualgpu.py
@@ -404,6 +404,9 @@ class VirtualGPU:
         if self.pool is not None:
             self.pool.close()
             self.pool.join()
+            self.pool = None
+            if self.use_pool:
+                self.pool = Pool(processes=len(self.sms))
 
         for sm in self.sms:
             sm.fetch_and_execute()


### PR DESCRIPTION
## Summary
- recreate pool in `VirtualGPU.synchronize`
- test launching two kernels sequentially when using a pool

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627a0633f4833186a102ed571173f2