### PR TITLE
Pin httpx to <0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Before running the test suite install the package with the optional dependencies
 pip install -e .[api]
 ```
 
+The API extras include `httpx`, which is pinned below version 0.24 for
+compatibility. This requirement is specified in both `pyproject.toml` and
+`requirements.txt`.
+
 Then install the development packages listed in `requirements.txt`:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,5 @@ include = ["py_virtual_gpu*"]
 
 [project.optional-dependencies]
 # Include httpx so FastAPI's TestClient works out of the box
-api = ["fastapi", "uvicorn[standard]", "httpx"]
+# Pin httpx below 0.24 for compatibility with our API tests
+api = ["fastapi", "uvicorn[standard]", "httpx<0.24"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
 uvicorn[standard]
-httpx
+httpx<0.24
 pytest
 numpy


### PR DESCRIPTION
## Summary
- pin httpx under 0.24 in optional dependencies
- update requirements.txt accordingly
- document httpx pinning in Development Setup section of README

## Testing
- `pip install -e .[api]`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627d88012c8331b48b2add6827a205